### PR TITLE
Implement contact events

### DIFF
--- a/module/body_state.h
+++ b/module/body_state.h
@@ -19,10 +19,14 @@ class PluggablePhysicsDirectBodyState : public PhysicsDirectBodyState {
 	_FORCE_INLINE_ ~PluggablePhysicsDirectBodyState() {}
 
 	struct physics_body_state state;
-	index_t body;
+	mutable struct physics_body_contact contact;
 	PluggablePhysicsServer *server;
 	PluggablePhysicsDirectSpaceState *space_state_singleton;
+	index_t body;
 	real_t delta;
+	mutable uint32_t contact_index;
+
+	_FORCE_INLINE_ const struct physics_body_contact *_select_contact(int id) const;
 
 public:
 	virtual Vector3 get_total_gravity() const;

--- a/module/generate.py
+++ b/module/generate.py
@@ -80,6 +80,11 @@ API_CUSTOM_FUNCTIONS = {
         ('index_t', 'area'),
         ('struct physics_area_monitor_event *', 'event')
     ]),
+    'body_get_contact': ('void', [
+        ('index_t', 'body'),
+        ('uint32_t', 'id'),
+        ('struct physics_body_contact *', 'contact'),
+    ]),
     'body_get_direct_state': ('void', [
         ('index_t', 'body'),
         ('struct physics_body_state *', 'state')
@@ -119,10 +124,22 @@ API_STRUCTS = {
         ('godot_vector3', 'inv_inertia'),
         ('godot_basis', 'inv_inertia_tensor'),
         ('index_t', 'space'),
+        ('uint32_t', 'contact_count'),
         ('real_t', 'inv_mass'),
         ('real_t', 'angular_damp'),
         ('real_t', 'linear_damp'),
         ('bool', 'sleeping'),
+    ],
+    'physics_body_contact': [
+        ('godot_vector3', 'position'),
+        ('godot_vector3', 'velocity'),
+        ('godot_vector3', 'local_position'),
+        ('godot_vector3', 'local_normal'),
+        ('index_t', 'index'),
+        ('uint32_t', 'shape'),
+        ('uint32_t', 'local_shape'),
+        ('int', 'object_id'),
+        ('float', 'impulse'),
     ],
     'physics_ray_info': [
         ('godot_vector3', 'from'),

--- a/module/server.h
+++ b/module/server.h
@@ -23,6 +23,12 @@
 } while (0)
 
 
+#define EXEC_V_FFI_FN(_v_, _server_, _fn_, ...) do { \
+	ERR_FAIL_COND_V_MSG((_server_)->fn_table._fn_ == nullptr, _v_, "Not implemented"); \
+	(*(_server_)->fn_table._fn_)(__VA_ARGS__); \
+} while (0)
+
+
 class PluggablePhysicsRID_Data : public RID_Data {
 	friend class PluggablePhysicsServer;
 	index_t index;

--- a/rapier3d/src/area.rs
+++ b/rapier3d/src/area.rs
@@ -1,8 +1,8 @@
-use crate::server::{
-	AreaIndex, Body, BodyIndex, Instance, MapIndex, ObjectID, ShapeIndex, SpaceIndex,
-	AREA_ID,
-};
+use crate::body::Body;
 use crate::indices::Indices;
+use crate::server::{
+	AreaIndex, BodyIndex, Instance, MapIndex, ObjectID, ShapeIndex, SpaceIndex, AREA_ID,
+};
 use crate::util::*;
 use core::mem;
 use gdnative::core_types::*;
@@ -493,9 +493,7 @@ impl Area {
 		};
 		let gravity = self.gravity(area);
 		for body in self.intersecting_bodies.iter() {
-			let body = bodies
-				.get_mut(body.into())
-				.expect("Invalid body index");
+			let body = bodies.get_mut(body.into()).expect("Invalid body index");
 			body.area_apply_overrides(
 				rigid_bodies,
 				replace,

--- a/rapier3d/src/body.rs
+++ b/rapier3d/src/body.rs
@@ -1,0 +1,718 @@
+use crate::area::Gravity;
+use crate::space::Space;
+use crate::indices::Indices;
+use crate::server::{Shape, BodyIndex, Instance, MapIndex, ObjectID, ShapeIndex, SpaceIndex, BODY_ID};
+use crate::util::*;
+use gdnative::core_types::*;
+use rapier3d::dynamics::{MassProperties, RigidBody, RigidBodyHandle, RigidBodySet, BodyStatus};
+use rapier3d::geometry::{
+	Collider, ColliderBuilder, ColliderHandle, InteractionGroups, SharedShape,
+};
+use rapier3d::math::Isometry;
+use rapier3d::na::Point3;
+
+pub struct BodyShape {
+	index: ShapeIndex,
+	transform: Isometry<f32>,
+	scale: Vector3,
+	enabled: bool,
+}
+
+pub struct Body {
+	body: Instance<(RigidBodyHandle, Vec<Option<ColliderHandle>>), RigidBody>,
+	object_id: Option<ObjectID>,
+	shapes: Vec<BodyShape>,
+	scale: Vector3,
+
+	exclusions: Vec<BodyIndex>,
+	collision_groups: InteractionGroups,
+	ray_pickable: bool,
+
+	linear_damp: f32,
+	angular_damp: f32,
+	restitution: f32,
+	friction: f32,
+
+	transform_stale: bool,
+	inertia_stale: bool,
+
+	omit_force_integration: bool,
+
+	area_gravity: Option<Vector3>,
+	area_linear_damp: Option<(f32, u32)>,
+	area_angular_damp: Option<(f32, u32)>,
+	area_replace: bool,
+	area_lock: bool,
+
+	index: Option<BodyIndex>,
+}
+
+#[derive(Debug)]
+pub struct AlreadyExcluded;
+
+#[derive(Debug)]
+pub struct InvalidShape;
+
+impl Body {
+	pub fn new(body: RigidBody) -> Self {
+		Self {
+			body: Instance::Loose(body),
+			object_id: None,
+			shapes: Vec::new(),
+			scale: Vector3::one(),
+
+			exclusions: Vec::new(),
+			collision_groups: InteractionGroups::default(),
+			ray_pickable: true,
+
+			angular_damp: -1.0,
+			linear_damp: -1.0,
+			restitution: 0.0,
+			friction: 1.0,
+
+			transform_stale: false,
+			inertia_stale: false,
+
+			omit_force_integration: false,
+
+			area_gravity: None,
+			area_linear_damp: None,
+			area_angular_damp: None,
+			area_lock: false,
+			area_replace: false,
+
+			index: None,
+		}
+	}
+
+	pub fn as_attached(&self) -> Option<(RigidBodyHandle, SpaceIndex)> {
+		if let Instance::Attached(body, space) = &self.body {
+			Some((body.0, *space))
+		} else {
+			None
+		}
+	}
+
+	/// Calls the given function with a reference to this body's [`RigidBody`].
+	fn map_rigidbody<F, R>(&self, f: F) -> R
+	where
+		F: FnOnce(&RigidBody) -> R
+	{
+		match &self.body {
+			Instance::Attached((body, _), space) => {
+				space.map(|space| f(space.get_body(*body).expect("Invalid body handle"))).expect("Invalid space handle")
+			}
+			Instance::Loose(body) => f(body),
+		}
+	}
+
+	/// Calls the given function with a reference to this body's [`RigidBody`].
+	fn map_rigidbody_mut<F, R>(&mut self, f: F) -> R
+	where
+		F: FnOnce(&mut RigidBody) -> R
+	{
+		match &mut self.body {
+			Instance::Attached((body, _), space) => {
+				space.map_mut(|space| f(space.get_body_mut(*body).expect("Invalid body handle"))).expect("Invalid space handle")
+			}
+			Instance::Loose(body) => f(body),
+		}
+	}
+
+	/// Calls the given function on all of the colliders of this body, if any.
+	fn map_colliders<F>(&mut self, mut f: F)
+	where
+		F: FnMut(&mut Collider)
+	{
+		if let Instance::Attached((_, ch), space) = &mut self.body {
+			space
+				.map_mut(|space| {
+					for ch in ch.iter().filter_map(Option::as_ref) {
+						f(space.colliders_mut().get_mut(*ch).expect("Invalid collider handle"));
+					}
+				})
+				.expect("Invalid space handle");
+		}
+	}
+
+	/// Attaches the given shape to this body
+	pub fn add_shape(&mut self, shape: &Shape, transform: &Transform, enabled: bool) {
+		self.shapes.push(BodyShape {
+			index: shape.index(),
+			transform: transform_to_isometry(*transform),
+			enabled,
+			scale: Vector3::one(),
+		});
+		self.inertia_stale = true
+	}
+
+	/// Recalculates the inertia based on all active shapes
+	fn recalculate_inertia(&mut self, body: &mut RigidBody, shapes: &mut Indices<Shape>) {
+		// TODO avoid calculating the MassProperties twice
+		let mut mp = Vec::with_capacity(self.shapes.len());
+		for shape in self.shapes.iter() {
+			if shape.enabled {
+				let trf = shape.transform;
+				let shape = shapes.get(shape.index.into()).expect("Invalid shape index");
+				mp.push((trf, shape.shape().clone()));
+			}
+		}
+		let mp_f = MassProperties::from_compound(1.0, &mp[..]);
+		let ratio = mp_f.inv_mass / body.mass_properties().inv_mass;
+		let mut mp = MassProperties::from_compound(ratio, &mp[..]);
+		// Workaround for https://github.com/dimforge/parry/issues/20
+		if mp.local_com.x.is_nan() || mp.local_com.x.is_infinite() {
+			mp.local_com = Point3::new(0.0, 0.0, 0.0);
+		};
+		body.set_mass_properties(mp, true);
+		self.inertia_stale = false;
+	}
+
+	fn set_shape_userdata(collider: &mut Collider, body: BodyIndex, shape: u32) {
+		let body = body.index() as u128 | ((body.generation() as u128) << 32);
+		let shape = (shape as u128) << 64;
+		collider.user_data = body | shape;
+	}
+
+	pub fn get_shape_userdata(collider: &Collider) -> (BodyIndex, u32) {
+		let body = collider.user_data as u64;
+		let shape = (collider.user_data >> 64) as u32;
+		(BodyIndex::new(body as u32, (body >> 32) as u16), shape)
+	}
+
+	pub fn object_id(&self) -> Option<ObjectID> {
+		self.object_id
+	}
+
+	/// Creates shapes according to shape enable status and transform
+	fn create_shapes(&self) -> Vec<Option<(SharedShape, &Isometry<f32>)>> {
+		let mut shapes = Vec::with_capacity(self.shapes.len());
+		for shape in self.shapes.iter() {
+			if shape.enabled {
+				let transform = shape.transform;
+				let shape_scale = transform.rotation * vec_gd_to_na(shape.scale);
+				let shape_scale = vec_gd_to_na(self.scale).component_mul(&shape_scale);
+				let shape_scale = vec_na_to_gd(shape_scale);
+				shape
+					.index
+					.map(|s| shapes.push(Some((s.scaled(shape_scale), &shape.transform))))
+					.expect("Shape is invalid");
+			} else {
+				shapes.push(None);
+			}
+		}
+		shapes
+	}
+
+	/// Creates colliders according to shape enable status and transform
+	fn create_colliders(&self, index: BodyIndex) -> Vec<Option<Collider>> {
+		let mut colliders = Vec::with_capacity(self.shapes.len());
+		for (i, e) in self.create_shapes().into_iter().enumerate() {
+			if let Some((shape, transform)) = e {
+				let mut collider = ColliderBuilder::new(shape)
+					.position_wrt_parent(*transform)
+					.collision_groups(self.collision_groups)
+					.restitution(self.restitution)
+					.friction(self.friction)
+					.build();
+				Body::set_shape_userdata(&mut collider, index, i as u32);
+				colliders.push(Some(collider));
+			} else {
+				colliders.push(None);
+			}
+		}
+		colliders
+	}
+
+	/// Store the given index in the userdata
+	pub fn set_index(&mut self, index: BodyIndex) {
+		assert_eq!(self.index, None, "Index is already set");
+		self.index = Some(index);
+		let (i, g) = (index.index(), index.generation());
+		if let Instance::Loose(body) = &mut self.body {
+			body.user_data = i as u128 | (g as u128) << 32 | (BODY_ID as u128) << 48;
+		} else {
+			panic!("Body is already assigned to a space");
+		}
+	}
+
+	/// Returns the index of this body
+	pub fn index(&self) -> BodyIndex {
+		self.index.expect("Index is not set")
+	}
+
+	/// Get the index from the given body's userdata
+	pub fn get_index(body: &RigidBody) -> BodyIndex {
+		let body = body.user_data as u64;
+		BodyIndex::new(body as u32, (body >> 32) as u16)
+	}
+
+	/// Frees this body, removing it from it's attached space (if any)
+	pub fn free(self) {
+		if let Instance::Attached((rb, _), space) = &self.body {
+			space
+				.map_mut(|space| {
+					space.remove_body(*rb);
+				})
+				.expect("Invalid space");
+		}
+	}
+
+	/// Adds any forces and damp overrides from an area
+	pub fn area_apply_overrides(
+		&mut self,
+		bodies: &RigidBodySet,
+		replace: bool,
+		gravity: &Gravity,
+		linear_damp: f32,
+		angular_damp: f32,
+		lock: bool,
+	) {
+		if !self.area_lock {
+			let g = match gravity {
+				Gravity::Direction(g) => g.gravity(),
+				Gravity::Point(p) => {
+					if let Instance::Attached((rb, _), _) = &self.body {
+						// Based on code in rigid_body_bullet.cpp
+						// I'm not sure what the logic behind the scale factor is but w/e
+						let body = &bodies[*rb];
+						let dir = p.point() - vec_na_to_gd(body.position().translation.vector);
+						let dist = dir.length();
+						if dist > 0.0 {
+							let scale = p.distance_scale();
+							if scale > 0.0 {
+								let f = dist.mul_add(p.distance_scale(), 1.0);
+								(dir * p.gravity()) / ((f * f) * dist)
+							} else {
+								(dir * p.gravity()) / dist
+							}
+						} else {
+							// We can't divide by 0, so pretend there is no force in the middle of a thing
+							Vector3::zero()
+						}
+					} else {
+						unreachable!();
+					}
+				}
+			};
+			if replace {
+				self.area_gravity = Some(g);
+				self.area_linear_damp = if linear_damp >= 0.0 {
+					Some((linear_damp, 1))
+				} else {
+					None
+				};
+				self.area_angular_damp = if angular_damp >= 0.0 {
+					Some((angular_damp, 1))
+				} else {
+					None
+				};
+				self.area_replace = true;
+			} else {
+				self.area_gravity = if let Some(ag) = self.area_gravity {
+					Some(ag + g)
+				} else {
+					Some(g)
+				};
+				self.area_linear_damp = if let Some((d, i)) = self.area_linear_damp {
+					Some((linear_damp + d, i + 1))
+				} else {
+					Some((linear_damp, 1))
+				};
+				self.area_angular_damp = if let Some((d, i)) = self.area_linear_damp {
+					Some((angular_damp + d, i + 1))
+				} else {
+					Some((angular_damp, 1))
+				};
+			}
+			self.area_lock = lock;
+		}
+	}
+
+	/// Applies any forces and damp overrides added by areas and clears the area lock
+	pub fn apply_area_overrides(
+		&mut self,
+		body: &mut RigidBody,
+		space_linear_damp: f32,
+		space_angular_damp: f32,
+	) {
+		let current_gravity_scale = body.gravity_scale();
+		#[allow(clippy::float_cmp)] // Shut up Clippy
+		if let Some(g) = self.area_gravity {
+			let s = if self.area_replace { 0.0 } else { 1.0 };
+			body.set_gravity_scale(s, s != current_gravity_scale);
+			body.apply_force(vec_gd_to_na(g) * body.mass(), s != current_gravity_scale);
+		} else {
+			body.set_gravity_scale(1.0, current_gravity_scale != 1.0);
+		}
+		body.linear_damping = if let Some((d, i)) = self.area_linear_damp {
+			let i = i as f32;
+			if self.area_replace {
+				d / i
+			} else if self.linear_damp < 0.0 {
+				(space_linear_damp + d * i) / (i + 1.0)
+			} else {
+				(self.linear_damp + d * i) / (i + 1.0)
+			}
+		} else if self.linear_damp < 0.0 {
+			space_linear_damp
+		} else {
+			self.linear_damp
+		};
+		body.angular_damping = if let Some((d, i)) = self.area_angular_damp {
+			let i = i as f32;
+			if self.area_replace {
+				d / i
+			} else if self.angular_damp < 0.0 {
+				(space_angular_damp + d * i) / (i + 1.0)
+			} else {
+				(self.angular_damp + d * i) / (i + 1.0)
+			}
+		} else if self.linear_damp < 0.0 {
+			space_linear_damp
+		} else {
+			self.linear_damp
+		};
+		self.area_gravity = None;
+		self.area_linear_damp = None;
+		self.area_angular_damp = None;
+		self.area_replace = false;
+		self.area_lock = false;
+	}
+
+	/// Adds body with which this body will not collide with
+	///
+	/// # Returns
+	///
+	/// `Err(AlreadyExcluded)` if the bodies already excluded each other, `Ok(())` otherwise
+	pub fn add_exclusion(&mut self, other: &mut Self) -> Result<(), AlreadyExcluded> {
+		let other_index = other.index();
+		if !self.exclusions.contains(&other_index) {
+			let self_index = self.index();
+			assert!(
+				!other.exclusions.contains(&self_index),
+				"Other body already excludes self"
+			);
+			self.exclusions.push(other_index);
+			other.exclusions.push(self_index);
+			if let Instance::Attached(_, space) = &self.body {
+				space
+					.map_mut(|space| {
+						space
+							.add_body_exclusion(self_index, other_index)
+							.expect("Exclusion already added");
+					})
+					.expect("Invalid space");
+			}
+			Ok(())
+		} else {
+			Err(AlreadyExcluded)
+		}
+	}
+
+	/// Applies a force to the body at the given position. The force must be in global space.
+	pub fn add_force_at_position(&mut self, force: Vector3, position: Vector3) {
+		let force = vec_gd_to_na(force);
+		let position = Point3::from(vec_gd_to_na(position));
+		self.map_rigidbody_mut(|body| body.apply_force_at_point(force, position, true));
+	}
+
+	/// Applies an impulse to the body at the given position. The impulse must be in global space.
+	/// The impulse is applied immediately.
+	pub fn add_impulse_at_position(&mut self, impulse: Vector3, position: Vector3) {
+		let impulse = vec_gd_to_na(impulse);
+		let position = Point3::from(vec_gd_to_na(position));
+		self.map_rigidbody_mut(|body| body.apply_impulse_at_point(impulse, position, true));
+	}
+
+	/// Returns the translation of this body
+	pub fn translation(&self) -> Vector3 {
+		self.map_rigidbody(|body| vec_na_to_gd(body.position().translation.vector))
+	}
+
+	/// Applies the transform and scales the colliders
+	pub fn set_transform(&mut self, transform: &Transform) {
+		let (iso, scl) = transform_to_isometry_and_scale(transform);
+		self.scale = scl;
+		self.map_rigidbody_mut(|body| body.set_position(iso, true));
+		// FIXME inefficient as hell
+		let shapes = self.create_shapes().into_iter().map(|v| v.map(|v| v.0)).collect::<Vec<_>>();
+		self.inertia_stale |= match &mut self.body {
+			Instance::Attached((body, _), space) => {
+				let body = *body;
+				space
+					.map_mut(|space| {
+						let body = space.get_body_mut(body).expect("Invalid body handle");
+						body.set_position(iso, true);
+						let iter = body.colliders().iter().copied().zip(shapes.into_iter()).collect::<Vec<_>>();
+						for (handle, shape) in iter {
+							space
+								.get_collider_mut(handle)
+								.expect("Invalid collider handle")
+								.set_shape(shape.unwrap());
+						}
+					})
+					.expect("Invalid space handle");
+				true
+			}
+			Instance::Loose(body) => {
+				body.set_position(iso, true);
+				false
+			}
+		}
+	}
+
+	/// Sets the linear velocity of this body
+	pub fn set_linear_velocity(&mut self, velocity: Vector3) {
+		self.map_rigidbody_mut(|body| body.set_linvel(vec_gd_to_na(velocity), true));
+	}
+
+	/// Sets the angular velocity of this body
+	pub fn set_angular_velocity(&mut self, velocity: Vector3) {
+		self.map_rigidbody_mut(|body| body.set_angvel(vec_gd_to_na(velocity), true));
+	}
+
+	/// Sets whether this body should sleep or not
+	pub fn set_sleeping(&mut self, sleep: bool) {
+		self.map_rigidbody_mut(|body| body.activation.sleeping = sleep);
+	}
+
+	/// Sets the energy threshold when this body will wake up or sleep.
+	/// A negative value disables sleep.
+	pub fn set_sleep_threshold(&mut self, threshold: f32) {
+		self.map_rigidbody_mut(|body| body.activation.threshold = threshold);
+	}
+
+	/// Attach or remove a object id to this body.
+	pub fn set_object_id(&mut self, id: Option<ObjectID>) {
+		self.object_id = id;
+	}
+
+	/// Sets whether this body can be picked up by raycasts.
+	pub fn set_ray_pickable(&mut self, pickable: bool) {
+		self.ray_pickable = pickable;
+	}
+
+	// TODO get rid of this ugly thing and return some state struct instead
+	pub fn read_body<F>(&self, f: F)
+	where
+		F: FnOnce(&RigidBody, Option<SpaceIndex>),
+	{
+		match &self.body {
+			Instance::Attached((b, _), sh) => {
+				sh.map(|s| f(s.get_body(*b).expect("Invalid body handle"), Some(*sh)))
+					.expect("Invalid space handle");
+			}
+			Instance::Loose(b) => f(b, None),
+		}
+	}
+
+	/// Sets the space of this body
+	pub fn set_space(&mut self, space: &mut Space) {
+		if let Instance::Attached(_, _) = &self.body {
+			self.remove_from_space();
+		}
+		let colliders = self.create_colliders(self.index());
+
+		self.inertia_stale = true;
+
+		let self_index = self.index();
+		// TODO this is ugly
+		let b = core::mem::replace(
+			&mut self.body,
+			Instance::Attached(
+				(RigidBodyHandle::invalid(), Vec::new()),
+				SpaceIndex::new(0, 0),
+			),
+		);
+
+		self.body = if let Instance::Loose(b) = b {
+			let mut collider_handles = Vec::with_capacity(colliders.len());
+			let mp = *b.mass_properties();
+			let handle = space.add_body(b);
+			for collider in colliders {
+				let handle = collider.map(|c| space.add_collider(c, handle));
+				collider_handles.push(handle);
+			}
+			for &exclude in self.exclusions.iter() {
+				let _ = space.add_body_exclusion(self_index, exclude);
+			}
+			space
+				.get_body_mut(handle)
+				.unwrap()
+				.set_mass_properties(mp, false);
+			let rb = space.get_body_mut(handle).unwrap();
+			self.recalculate_inertia(rb, &mut ShapeIndex::write_all());
+			Instance::Attached((handle, collider_handles), space.index())
+		} else {
+			unreachable!();
+		}
+	}
+
+	/// Removes the body from it's space, if any
+	pub fn remove_from_space(&mut self) {
+		if let Instance::Attached((body, _), space) = &self.body {
+			let body = space
+				.map_mut(|space| space.remove_body(*body).expect("Invalid body handle"))
+				.expect("Failed to modify space");
+			self.body = Instance::Loose(body);
+		}
+	}
+
+	/// Sets the transform of a shape and optionally scales it
+	pub fn set_shape_transform(&mut self, shape: u32, transform: &Transform, scale: bool) -> Result<(), InvalidShape> {
+		if let Some(shp) = self.shapes.get_mut(shape as usize) {
+			let (iso, scl) = transform_to_isometry_and_scale(transform);
+			shp.transform = iso;
+			shp.scale = scl;
+			if let Instance::Attached((body, colliders), space) = &self.body {
+				if let Some(collider) = colliders[shape as usize] {
+					let shape_scale = iso.rotation * vec_gd_to_na(shp.scale);
+					let shape_scale = vec_gd_to_na(self.scale).component_mul(&shape_scale);
+					let shape_scale = vec_na_to_gd(shape_scale);
+					let shape = shp.index.map(|shape| shape.scaled(shape_scale)).expect("Invalid shape index");
+				   space.map_mut(|space| {
+						let c = space
+							.get_collider_mut(collider)
+							.expect("Invalid collider handle");
+						c.set_shape(shape);
+						c.set_position_wrt_parent(iso);
+				   }).expect("Invalid space index");
+				}
+			}
+			Ok(())
+		} else {
+			Err(InvalidShape)
+		}
+	}
+
+	/// Sets the transform of a shape and optionally scales it
+	pub fn set_shape_enable(&mut self, shape: u32, enable: bool) -> Result<(), InvalidShape> {
+		if let Some(shape) = self.shapes.get_mut(shape as usize) {
+			shape.enabled = enable;
+			Ok(())
+		} else {
+			Err(InvalidShape)
+		}
+	}
+
+	/// Sets whether to clear any external forces such as gravity
+	pub fn set_omit_force_integration(&mut self, enable: bool) {
+		self.omit_force_integration = enable;
+		let g_scale = if enable { 0.0 } else { 1.0 };
+		match &mut self.body {
+			Instance::Attached((rb, _), space) => {
+				space
+					.map_mut(|space| {
+						space
+							.bodies_mut()
+							.get_mut(*rb)
+							.expect("Invalid body handle")
+							.set_gravity_scale(g_scale, true);
+					})
+					.expect("Invalid space");
+			}
+			Instance::Loose(body) => {
+				body.set_gravity_scale(g_scale, true);
+			}
+		}
+	}
+
+	/// Sets whether this body is static, kinematic or dynamic
+	pub fn set_body_status(&mut self, status: BodyStatus) {
+		match &mut self.body {
+			Instance::Attached((rb, _), space) => {
+				space
+					.map_mut(|s| {
+						s.bodies_mut()
+							.get_mut(*rb)
+							.expect("Invalid body handle")
+							.set_body_status(status)
+					})
+					.expect("Invalid space");
+			}
+			Instance::Loose(body) => {
+				body.set_body_status(status);
+			}
+		}
+	}
+
+	/// Sets the groups of this body
+	pub fn set_groups(&mut self, groups: u16) {
+		self.collision_groups.with_groups(groups);
+		self.update_interaction_groups();
+	}
+
+	/// Sets the mask of this body
+	pub fn set_mask(&mut self, mask: u16) {
+		self.collision_groups.with_mask(mask);
+		self.update_interaction_groups();
+	}
+
+	/// Updates the [`InteractionGroups`] of the colliders attached to this body
+	fn update_interaction_groups(&mut self) {
+		let cg = self.collision_groups;
+		self.map_colliders(|collider| collider.set_collision_groups(cg));
+	}
+
+	/// Sets the mass of this body
+	pub fn set_mass(&mut self, mass: f32) {
+		self.map_rigidbody_mut(|body| {
+			let mut p = *body.mass_properties();
+			p.inv_mass = 1.0 / mass;
+			body.set_mass_properties(p, true);
+		});
+		self.inertia_stale = true;
+	}
+
+	/// Sets the linear damp of this body
+	pub fn set_linear_damp(&mut self, damp: f32) {
+		self.map_rigidbody_mut(|body| body.linear_damping = damp);
+	}
+
+	/// Sets the angular damp of this body
+	pub fn set_angular_damp(&mut self, damp: f32) {
+		self.map_rigidbody_mut(|body| body.angular_damping = damp);
+	}
+
+	/// Sets the gravity scale of this body. This wakes up the body.
+	pub fn set_gravity_scale(&mut self, scale: f32) {
+		self.map_rigidbody_mut(|body| body.set_gravity_scale(scale, true));
+	}
+
+	/// Sets the restitution of this body and it's colliders, if any.
+	pub fn set_restitution(&mut self, restitution: f32) {
+		self.restitution = restitution;
+		self.map_colliders(|collider| collider.restitution = restitution);
+	}
+
+	/// Sets the friction of this body and it's colliders, if any.
+	pub fn set_friction(&mut self, friction: f32) {
+		self.friction = friction;
+		self.map_colliders(|collider| collider.friction = friction);
+	}
+
+	/// Removes the given shape from this body and any colliders
+	pub fn remove_shape(&mut self, shape: u32) -> Result<(), InvalidShape> {
+		if (shape as usize) < self.shapes.len() {
+			self.shapes.remove(shape as usize);
+			if let Instance::Attached((_, colliders), space) = &self.body {
+				if let Some(collider) = colliders[shape as usize] {
+					space.map_mut(|space| {
+						space.remove_collider(collider).expect("Invalid collider handle");
+					}).expect("Invalid space handle");
+				}
+			}
+			Ok(())
+		} else {
+			Err(InvalidShape)
+		}
+	}
+
+	/// Updates the state of this rigidbody if it's stale
+	pub fn refresh_state(&mut self, body: &mut RigidBody, shapes: &mut Indices<Shape>) {
+		if self.inertia_stale {
+			self.recalculate_inertia(body, shapes);
+		}
+	}
+}

--- a/rapier3d/src/indices.rs
+++ b/rapier3d/src/indices.rs
@@ -105,7 +105,7 @@ impl<T> Indices<T> {
 			} else {
 				None
 			};
-			let b = if let Some(Entry::Occupied { item, generation }) = r.get_mut(bi - ai) {
+			let b = if let Some(Entry::Occupied { item, generation }) = r.get_mut(bi - ai - 1) {
 				if *generation == bg {
 					Some(item)
 				} else {
@@ -150,5 +150,27 @@ impl Index {
 
 	fn split(self) -> (u32, u16) {
 		(self.index, self.generation)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn get2_mut() {
+		let mut inds = Indices::new();
+		let a = inds.add("foo");
+		let b = inds.add("bar");
+		let (a, b) = inds.get2_mut(a, b);
+		assert_eq!(a, Some(&mut "foo"));
+		assert_eq!(b, Some(&mut "bar"));
+
+		let mut inds = Indices::new();
+		let a = inds.add("bar");
+		let b = inds.add("foo");
+		let (a, b) = inds.get2_mut(a, b);
+		assert_eq!(a, Some(&mut "bar"));
+		assert_eq!(b, Some(&mut "foo"));
 	}
 }

--- a/rapier3d/src/indices.rs
+++ b/rapier3d/src/indices.rs
@@ -16,7 +16,7 @@ pub struct Index {
 
 enum Entry<T> {
 	Free { next: Option<u32> },
-	Occupied { item: T, generation: u16 }
+	Occupied { item: T, generation: u16 },
 }
 
 impl<T> Indices<T> {
@@ -51,7 +51,9 @@ impl<T> Indices<T> {
 		if let Some(e) = self.elements.get_mut(index.index as usize) {
 			if let Entry::Occupied { generation, .. } = e {
 				if *generation == index.generation {
-					let entry = Entry::Free { next: self.free_slot };
+					let entry = Entry::Free {
+						next: self.free_slot,
+					};
 					self.free_slot = Some(index.index);
 					if let Entry::Occupied { item, .. } = mem::replace(e, entry) {
 						return Some(item);
@@ -86,21 +88,37 @@ impl<T> Indices<T> {
 
 	pub fn get2_mut(&mut self, index_a: Index, index_b: Index) -> (Option<&mut T>, Option<&mut T>) {
 		let (a, b) = (index_a.split(), index_b.split());
-		let (a, b, swapped) = if a.0 < b.0 { (a, b, false) } else { (b, a, true) };
+		let (a, b, swapped) = if a.0 < b.0 {
+			(a, b, false)
+		} else {
+			(b, a, true)
+		};
 		let ((ai, ag), (bi, bg)) = ((a.0 as usize, a.1), (b.0 as usize, b.1));
 		if ai < self.elements.len() {
 			let (l, r) = self.elements.split_at_mut(ai + 1);
 			let a = if let Entry::Occupied { item, generation } = &mut l[ai] {
-				if *generation == ag { Some(item) } else { None }
+				if *generation == ag {
+					Some(item)
+				} else {
+					None
+				}
 			} else {
 				None
 			};
 			let b = if let Some(Entry::Occupied { item, generation }) = r.get_mut(bi - ai) {
-				if *generation == bg { Some(item) } else { None }
+				if *generation == bg {
+					Some(item)
+				} else {
+					None
+				}
 			} else {
 				None
 			};
-			if swapped { (b, a) } else { (a, b) }
+			if swapped {
+				(b, a)
+			} else {
+				(a, b)
+			}
 		} else {
 			(None, None)
 		}

--- a/rapier3d/src/lib.rs
+++ b/rapier3d/src/lib.rs
@@ -1,9 +1,10 @@
 #![feature(destructuring_assignment)]
 
 mod area;
+mod body;
+mod indices;
 mod server;
 mod space;
-mod indices;
 mod util;
 
 // TODO find a proper workaround for E0446

--- a/rapier3d/src/server/body.rs
+++ b/rapier3d/src/server/body.rs
@@ -1,19 +1,15 @@
 use super::index::BodyIndex;
 use super::*;
-use crate::area::Gravity;
+use crate::body::Body;
 use crate::util::*;
+use core::mem;
 use gdnative::core_types::*;
 use gdnative::{godot_error, godot_warn};
 use rapier3d::dynamics::{
-	ActivationStatus, BodyStatus, MassProperties, RigidBody, RigidBodyBuilder, RigidBodyHandle,
-	RigidBodySet,
-};
-use rapier3d::geometry::{
-	Collider, ColliderBuilder, ColliderHandle, InteractionGroups, SharedShape,
+	ActivationStatus, BodyStatus, RigidBody, RigidBodyBuilder, RigidBodyHandle,
 };
 use rapier3d::math::Isometry;
 use rapier3d::na;
-use std::mem;
 
 #[derive(Debug)]
 enum Type {
@@ -63,28 +59,6 @@ struct Shape {
 	transform: Isometry<f32>,
 	scale: Vector3,
 	enabled: bool,
-}
-
-pub struct Body {
-	body: Instance<(RigidBodyHandle, Vec<Option<ColliderHandle>>), RigidBody>,
-	object_id: Option<ObjectID>,
-	shapes: Vec<Shape>,
-	scale: Vector3,
-	exclusions: Vec<BodyIndex>,
-	collision_groups: InteractionGroups,
-
-	linear_damp: f32,
-	angular_damp: f32,
-	restitution: f32,
-	friction: f32,
-
-	omit_force_integration: bool,
-
-	area_gravity: Option<Vector3>,
-	area_linear_damp: Option<(f32, u32)>,
-	area_angular_damp: Option<(f32, u32)>,
-	area_replace: bool,
-	area_lock: bool,
 }
 
 impl Type {
@@ -150,311 +124,6 @@ impl Mode {
 	}
 }
 
-impl Body {
-	fn new(r#type: Type, sleep: bool) -> Self {
-		Self {
-			body: Instance::Loose(r#type.create_body(sleep)),
-			object_id: None,
-			shapes: Vec::new(),
-			scale: Vector3::one(),
-			exclusions: Vec::new(),
-			collision_groups: InteractionGroups::default(),
-
-			angular_damp: -1.0,
-			linear_damp: -1.0,
-
-			restitution: 0.0,
-			friction: 1.0,
-			omit_force_integration: false,
-
-			area_gravity: None,
-			area_linear_damp: None,
-			area_angular_damp: None,
-			area_lock: false,
-			area_replace: false,
-		}
-	}
-
-	fn map_shape_mut<F>(&mut self, index: u32, f: F)
-	where
-		F: FnOnce(&mut Shape),
-	{
-		if let Some(shape) = self.shapes.get_mut(index as usize) {
-			f(shape);
-		} else {
-			godot_error!("Invalid shape index");
-		}
-	}
-
-	pub fn as_attached(&self) -> Option<(RigidBodyHandle, SpaceIndex)> {
-		if let Instance::Attached(body, space) = &self.body {
-			Some((body.0, *space))
-		} else {
-			None
-		}
-	}
-
-	fn add_shape(&mut self, index: ShapeIndex, transform: &Transform, enabled: bool) {
-		self.shapes.push(Shape {
-			index,
-			transform: transform_to_isometry(*transform),
-			enabled,
-			scale: Vector3::one(),
-		});
-		self.recalculate_inertia();
-	}
-
-	/// Recalculates the inertia based on all active shapes
-	fn recalculate_inertia(&mut self) {
-		let shapes = &self.shapes;
-		// TODO avoid calculating the MassProperties twice
-		let calc_mp = |body: &mut RigidBody| {
-			let mut mp = Vec::with_capacity(shapes.len());
-			for shape in shapes.iter() {
-				if shape.enabled {
-					let trf = shape.transform;
-					let shape = shape
-						.index
-						.map(|shape| shape.shape().clone())
-						.expect("Invalid shape index");
-					mp.push((trf, shape));
-				}
-			}
-			let mp_f = MassProperties::from_compound(1.0, &mp[..]);
-			let ratio = mp_f.inv_mass / body.mass_properties().inv_mass;
-			let mut mp = MassProperties::from_compound(ratio, &mp[..]);
-			// Workaround for https://github.com/dimforge/parry/issues/20
-			if mp.local_com.x.is_nan() || mp.local_com.x.is_infinite() {
-				mp.local_com = na::Point3::new(0.0, 0.0, 0.0);
-			};
-			body.set_mass_properties(mp, true);
-		};
-		match &mut self.body {
-			Instance::Attached((body, _), space) => {
-				space
-					.map_mut(|space| {
-						calc_mp(
-							space
-								.bodies_mut()
-								.get_mut(*body)
-								.expect("Invalid body handle"),
-						)
-					})
-					.expect("Invalid space handle");
-			}
-			Instance::Loose(body) => calc_mp(body),
-		}
-	}
-
-	fn set_shape_userdata(collider: &mut Collider, body: BodyIndex, shape: u32) {
-		let body = body.index() as u128 | ((body.generation() as u128) << 32);
-		let shape = (shape as u128) << 64;
-		collider.user_data = body | shape;
-	}
-
-	pub fn get_shape_userdata(collider: &Collider) -> (BodyIndex, u32) {
-		let body = collider.user_data as u64;
-		let shape = (collider.user_data >> 64) as u32;
-		(BodyIndex::new(body as u32, (body >> 32) as u16), shape)
-	}
-
-	pub fn object_id(&self) -> Option<ObjectID> {
-		self.object_id
-	}
-
-	/// Creates shapes according to shape enable status and transform
-	fn create_shapes(&self) -> Vec<Option<(SharedShape, &Isometry<f32>)>> {
-		let mut shapes = Vec::with_capacity(self.shapes.len());
-		for shape in self.shapes.iter() {
-			if shape.enabled {
-				let transform = shape.transform;
-				let shape_scale = transform.rotation * vec_gd_to_na(shape.scale);
-				let shape_scale = vec_gd_to_na(self.scale).component_mul(&shape_scale);
-				let shape_scale = vec_na_to_gd(shape_scale);
-				let result = shape
-					.index
-					.map(|s| shapes.push(Some((s.scaled(shape_scale), &shape.transform))));
-				if result.is_err() {
-					godot_error!("Shape is invalid: {:?}", shape.index);
-					shapes.push(None); // Make sure the collider count does still match
-				}
-			} else {
-				shapes.push(None);
-			}
-		}
-		shapes
-	}
-
-	/// Creates colliders according to shape enable status and transform
-	fn create_colliders(&self, index: BodyIndex) -> Vec<Option<Collider>> {
-		let mut colliders = Vec::with_capacity(self.shapes.len());
-		for (i, e) in self.create_shapes().into_iter().enumerate() {
-			if let Some((shape, transform)) = e {
-				let mut collider = ColliderBuilder::new(shape)
-					.position_wrt_parent(*transform)
-					.collision_groups(self.collision_groups)
-					.restitution(self.restitution)
-					.friction(self.friction)
-					.build();
-				Body::set_shape_userdata(&mut collider, index, i as u32);
-				colliders.push(Some(collider));
-			} else {
-				colliders.push(None);
-			}
-		}
-		colliders
-	}
-
-	/// Store the given index in the userdata
-	fn set_index(&mut self, index: BodyIndex) {
-		if let Instance::Loose(body) = &mut self.body {
-			body.user_data = index.index() as u128 | ((index.generation() as u128) << 32);
-		} else {
-			// Indices shouldn't be able to change after being attached
-			unreachable!();
-		}
-	}
-
-	/// Get the index from the given body's userdata
-	pub fn get_index(body: &RigidBody) -> BodyIndex {
-		let body = body.user_data as u64;
-		BodyIndex::new(body as u32, (body >> 32) as u16)
-	}
-
-	/// Frees this body, removing it from it's attached space (if any)
-	fn free(self) {
-		if let Instance::Attached((rb, _), space) = &self.body {
-			space
-				.map_mut(|space| {
-					space.remove_body(*rb);
-				})
-				.expect("Invalid space");
-		}
-	}
-
-	/// Adds any forces and damp overrides from an area
-	pub fn area_apply_overrides(
-		&mut self,
-		bodies: &RigidBodySet,
-		replace: bool,
-		gravity: &Gravity,
-		linear_damp: f32,
-		angular_damp: f32,
-		lock: bool,
-	) {
-		if !self.area_lock {
-			let g = match gravity {
-				Gravity::Direction(g) => g.gravity(),
-				Gravity::Point(p) => {
-					if let Instance::Attached((rb, _), _) = &self.body {
-						// Based on code in rigid_body_bullet.cpp
-						// I'm not sure what the logic behind the scale factor is but w/e
-						let body = &bodies[*rb];
-						let dir = p.point() - vec_na_to_gd(body.position().translation.vector);
-						let dist = dir.length();
-						if dist > 0.0 {
-							let scale = p.distance_scale();
-							if scale > 0.0 {
-								let f = dist.mul_add(p.distance_scale(), 1.0);
-								(dir * p.gravity()) / ((f * f) * dist)
-							} else {
-								(dir * p.gravity()) / dist
-							}
-						} else {
-							// We can't divide by 0, so pretend there is no force in the middle of a thing
-							Vector3::zero()
-						}
-					} else {
-						unreachable!();
-					}
-				}
-			};
-			if replace {
-				self.area_gravity = Some(g);
-				self.area_linear_damp = if linear_damp >= 0.0 {
-					Some((linear_damp, 1))
-				} else {
-					None
-				};
-				self.area_angular_damp = if angular_damp >= 0.0 {
-					Some((angular_damp, 1))
-				} else {
-					None
-				};
-				self.area_replace = true;
-			} else {
-				self.area_gravity = if let Some(ag) = self.area_gravity {
-					Some(ag + g)
-				} else {
-					Some(g)
-				};
-				self.area_linear_damp = if let Some((d, i)) = self.area_linear_damp {
-					Some((linear_damp + d, i + 1))
-				} else {
-					Some((linear_damp, 1))
-				};
-				self.area_angular_damp = if let Some((d, i)) = self.area_linear_damp {
-					Some((angular_damp + d, i + 1))
-				} else {
-					Some((angular_damp, 1))
-				};
-			}
-			self.area_lock = lock;
-		}
-	}
-
-	/// Applies any forces and damp overrides added by areas and clears the area lock
-	pub fn apply_area_overrides(
-		&mut self,
-		body: &mut RigidBody,
-		space_linear_damp: f32,
-		space_angular_damp: f32,
-	) {
-		let current_gravity_scale = body.gravity_scale();
-		#[allow(clippy::float_cmp)] // Shut up Clippy
-		if let Some(g) = self.area_gravity {
-			let s = if self.area_replace { 0.0 } else { 1.0 };
-			body.set_gravity_scale(s, s != current_gravity_scale);
-			body.apply_force(vec_gd_to_na(g) * body.mass(), s != current_gravity_scale);
-		} else {
-			body.set_gravity_scale(1.0, current_gravity_scale != 1.0);
-		}
-		body.linear_damping = if let Some((d, i)) = self.area_linear_damp {
-			let i = i as f32;
-			if self.area_replace {
-				d / i
-			} else if self.linear_damp < 0.0 {
-				(space_linear_damp + d * i) / (i + 1.0)
-			} else {
-				(self.linear_damp + d * i) / (i + 1.0)
-			}
-		} else if self.linear_damp < 0.0 {
-			space_linear_damp
-		} else {
-			self.linear_damp
-		};
-		body.angular_damping = if let Some((d, i)) = self.area_angular_damp {
-			let i = i as f32;
-			if self.area_replace {
-				d / i
-			} else if self.angular_damp < 0.0 {
-				(space_angular_damp + d * i) / (i + 1.0)
-			} else {
-				(self.angular_damp + d * i) / (i + 1.0)
-			}
-		} else if self.linear_damp < 0.0 {
-			space_linear_damp
-		} else {
-			self.linear_damp
-		};
-		self.area_gravity = None;
-		self.area_linear_damp = None;
-		self.area_angular_damp = None;
-		self.area_replace = false;
-		self.area_lock = false;
-	}
-}
-
 pub fn init(ffi: &mut ffi::FFI) {
 	ffi.body_add_force(add_force);
 	ffi.body_add_shape(add_shape);
@@ -483,9 +152,9 @@ pub fn free(body: Body) {
 	body.free()
 }
 
-fn create(r#type: i32, sleep: bool) -> Option<Index> {
-	if let Ok(r#type) = Type::new(r#type) {
-		let index = BodyIndex::add(Body::new(r#type, sleep));
+fn create(typ: i32, sleep: bool) -> Option<Index> {
+	if let Ok(typ) = Type::new(typ) {
+		let index = BodyIndex::add(Body::new(typ.create_body(sleep)));
 		index.map_mut(|b| b.set_index(index)).unwrap();
 		Some(Index::Body(index))
 	} else {
@@ -498,192 +167,96 @@ fn add_collision_exception(body_a: Index, body_b: Index) {
 	if body_a == body_b {
 		return; // There is no point excluding the body from itself
 	}
-	map_or_err!(body_a, map_body_mut, |body_a, index_a| {
-		if let Index::Body(index_b) = body_b {
-			if !body_a.exclusions.contains(&index_b) {
-				body_a.exclusions.push(index_b);
-				if let Instance::Attached(_, space) = &body_a.body {
-					space
-						.map_mut(|space| {
-							if space.add_body_exclusion(index_a, index_b).is_err() {
-								godot_error!("Failed to remove body exclusion");
-							}
-						})
-						.expect("Invalid space");
+	if let Some(body_a) = body_a.as_body() {
+		if let Some(body_b) = body_b.as_body() {
+			let mut bodies = BodyIndex::write_all();
+			let (body_a, body_b) = bodies.get2_mut(body_a.into(), body_b.into());
+			if let Some(body_a) = body_a {
+				if let Some(body_b) = body_b {
+					// "Adding" the same exclusion multiple times is valid
+					let _ = body_a.add_exclusion(body_b);
+				} else {
+					godot_error!("No body at index B");
 				}
+			} else {
+				godot_error!("No body at index A");
 			}
+		} else {
+			godot_error!("Index B does not point to a body");
 		}
-	});
-	map_or_err!(body_b, map_body_mut, |body_b, _| {
-		if let Index::Body(index_a) = body_a {
-			if !body_b.exclusions.contains(&index_a) {
-				body_b.exclusions.push(index_a);
-			}
-		}
-	});
+	} else {
+		godot_error!("Index A does not point to a body");
+	}
 }
 
 fn add_force(body: Index, force: &Vector3, position: &Vector3) {
-	map_or_err!(body, map_body, |body, _| {
-		if let Instance::Attached((body, _), space) = &body.body {
-			space
-				.map_mut(|space| {
-					let body = space
-						.bodies_mut()
-						.get_mut(*body)
-						.expect("Invalid body handle");
-					let (position, force) = transform_force_arguments(body, position, force);
-					body.apply_force_at_point(force, position, true);
-				})
-				.expect("Invalid space handle");
-		} else {
-			godot_error!("Can't apply force to body outside space");
-		}
+	map_or_err!(body, map_body_mut, |body, _| {
+		let (position, force) = transform_force_arguments(body, position, force);
+		body.add_force_at_position(force, position);
 	});
 }
 
 fn add_shape(body: Index, shape: Index, transform: &Transform, disabled: bool) {
 	map_or_err!(body, map_body_mut, |body, _| {
-		if let Index::Shape(index) = shape {
-			body.add_shape(index, transform, !disabled);
-		} else {
-			godot_error!("ID does not point to a shape");
-		}
+		map_or_err!(shape, map_shape_mut, |shape, _| {
+			body.add_shape(shape, transform, !disabled);
+		});
 	});
 }
 
 fn apply_impulse(body: Index, position: &Vector3, impulse: &Vector3) {
-	map_or_err!(body, map_body, |body, _| {
-		if let Instance::Attached((body, _), space) = &body.body {
-			space
-				.map_mut(|space| {
-					let body = space
-						.bodies_mut()
-						.get_mut(*body)
-						.expect("Invalid body handle");
-					let (position, impulse) = transform_force_arguments(body, position, impulse);
-					body.apply_impulse_at_point(impulse, position, true);
-				})
-				.expect("Invalid space handle");
-		} else {
-			godot_error!("Can't apply impulse to body outside space");
-		}
+	map_or_err!(body, map_body_mut, |body, _| {
+		let (position, impulse) = transform_force_arguments(body, position, impulse);
+		body.add_impulse_at_position(impulse, position);
 	});
 }
 
 fn attach_object_instance_id(body: Index, id: u32) {
-	map_or_err!(body, map_body_mut, |v, _| v.object_id = ObjectID::new(id));
+	map_or_err!(body, map_body_mut, |b, _| b
+		.set_object_id(ObjectID::new(id)));
 }
 
 fn get_direct_state(body: Index, state: &mut ffi::PhysicsBodyState) {
 	map_or_err!(body, map_body, |body, _| {
-		match &body.body {
-			Instance::Attached((body, _), space) => {
-				space
-					.map(|s| {
-						let body = s.bodies().get(*body).expect("Invalid body handle");
-						state.set_transform(&isometry_to_transform(body.position()));
-						state.set_space(Index::Space(*space));
-						state.set_linear_velocity(vec_na_to_gd(*body.linvel()));
-						state.set_angular_velocity(vec_na_to_gd(*body.angvel()));
-						state.set_sleeping(body.is_sleeping());
-						state.set_linear_damp(body.linear_damping);
-						state.set_angular_damp(body.angular_damping);
-						let mp = body.mass_properties();
-						state.set_inv_mass(mp.inv_mass);
-						let inv_inertia_sqrt = vec_na_to_gd(mp.inv_principal_inertia_sqrt);
-						state.set_inv_inertia(inv_inertia_sqrt.component_mul(inv_inertia_sqrt));
-						let inv_inertia_tensor = mp.reconstruct_inverse_inertia_matrix();
-						state.set_inv_inertia_tensor(&mat3_to_basis(&inv_inertia_tensor));
-					})
-					.expect("Invalid space");
+		body.read_body(|body, space| {
+			if let Some(space) = space {
+				state.set_transform(&isometry_to_transform(body.position()));
+				state.set_space(Index::Space(space));
+				state.set_linear_velocity(vec_na_to_gd(*body.linvel()));
+				state.set_angular_velocity(vec_na_to_gd(*body.angvel()));
+				state.set_sleeping(body.is_sleeping());
+				state.set_linear_damp(body.linear_damping);
+				state.set_angular_damp(body.angular_damping);
+				let mp = body.mass_properties();
+				state.set_inv_mass(mp.inv_mass);
+				let inv_inertia_sqrt = vec_na_to_gd(mp.inv_principal_inertia_sqrt);
+				state.set_inv_inertia(inv_inertia_sqrt.component_mul(inv_inertia_sqrt));
+				let inv_inertia_tensor = mp.reconstruct_inverse_inertia_matrix();
+				state.set_inv_inertia_tensor(&mat3_to_basis(&inv_inertia_tensor));
 			}
-			Instance::Loose(_) => {}
-		}
+		});
 	});
 }
 
 fn remove_shape(body: Index, shape: i32) {
-	let shape = shape as usize;
-	map_or_err!(body, map_body_mut, |body, _| {
-		// TODO this can panic
-		body.shapes.remove(shape);
-		if let Instance::Attached((_, colliders), space) = &mut body.body {
-			space
-				.map_mut(|space| {
-					// TODO can panic too
-					colliders.remove(shape).map(|c| space.remove_collider(c));
-				})
-				.expect("Failed to modify space");
-		}
-	});
+	map_or_err!(body, map_body_mut, |body, _| body.remove_shape(shape as u32));
 }
 
 fn set_param(body: Index, param: i32, value: f32) {
 	let param = if let Ok(param) = Param::new(param, value) {
-		param
+		map_or_err!(body, map_body_mut, |body, _| {
+			match param {
+				Param::Mass(mass) => body.set_mass(mass),
+				Param::LinearDamp(damp) => body.set_linear_damp(damp),
+				Param::AngularDamp(damp) => body.set_angular_damp(damp),
+				Param::GravityScale(scale) => body.set_gravity_scale(scale),
+				Param::Bounce(bounce) => body.set_restitution(bounce),
+				Param::Friction(friction) => body.set_friction(friction),
+			}
+		});
 	} else {
 		godot_error!("Invalid param");
-		return;
 	};
-	let f = |body: &mut RigidBody| match param {
-		Param::Mass(mass) => {
-			let mut p = *body.mass_properties();
-			p.inv_mass = 1.0 / mass;
-			body.set_mass_properties(p, true);
-		}
-		Param::LinearDamp(damp) => body.linear_damping = damp,
-		Param::AngularDamp(damp) => body.angular_damping = damp,
-		Param::Bounce(_) | Param::Friction(_) => (),
-		Param::GravityScale(scale) => body.set_gravity_scale(scale, true),
-	};
-	map_or_err!(body, map_body_mut, |body, _| {
-		match param {
-			Param::Bounce(bounce) => body.restitution = bounce,
-			Param::Friction(friction) => body.friction = friction,
-			_ => (),
-		}
-		match &mut body.body {
-			Instance::Attached((rb, _), space) => {
-				space
-					.map_mut(|space| {
-						let rb = space
-							.bodies_mut()
-							.get_mut(*rb)
-							.expect("Invalid body handle");
-						f(rb);
-						match param {
-							Param::Bounce(bounce) => {
-								let colliders = Vec::from(rb.colliders());
-								for c in colliders.into_iter() {
-									let c = space
-										.colliders_mut()
-										.get_mut(c)
-										.expect("Invalid collider handle");
-									c.restitution = bounce;
-								}
-							}
-							Param::Friction(friction) => {
-								let colliders = Vec::from(rb.colliders());
-								for c in colliders.into_iter() {
-									let c = space
-										.colliders_mut()
-										.get_mut(c)
-										.expect("Invalid collider handle");
-									c.friction = friction;
-								}
-							}
-							_ => (),
-						}
-					})
-					.expect("Invalid space handle");
-			}
-			Instance::Loose(rb) => {
-				f(rb);
-			}
-		}
-		body.recalculate_inertia();
-	});
 }
 
 fn set_collision_layer(body: Index, layer: u32) {
@@ -691,23 +264,7 @@ fn set_collision_layer(body: Index, layer: u32) {
 	if ((layer >> 16) & 0xf) != 0 && ((layer >> 16) & 0xf) != 0xf {
 		godot_warn!("Rapier3D only supports 16 bit collision groups. Don't use the upper 16 bits");
 	}
-	map_or_err!(body, map_body_mut, |body, _| {
-		body.collision_groups.with_groups(layer as u16);
-		let cg = body.collision_groups;
-		if let Instance::Attached((_, ch), space) = &mut body.body {
-			space
-				.map_mut(|space| {
-					for ch in ch.iter().filter_map(Option::as_ref) {
-						space
-							.colliders_mut()
-							.get_mut(*ch)
-							.expect("Invalid collider")
-							.set_collision_groups(cg);
-					}
-				})
-				.expect("Invalid space");
-		}
-	});
+	map_or_err!(body, map_body_mut, |body, _| body.set_groups(layer as u16));
 }
 
 fn set_collision_mask(body: Index, mask: u32) {
@@ -715,23 +272,7 @@ fn set_collision_mask(body: Index, mask: u32) {
 	if ((mask >> 16) & 0xf) != 0 && ((mask >> 16) & 0xf) != 0xf {
 		godot_warn!("Rapier3D only supports 16 bit collision groups. Don't use the upper 16 bits");
 	}
-	map_or_err!(body, map_body_mut, |body, _| {
-		body.collision_groups.with_mask(mask as u16);
-		let cg = body.collision_groups;
-		if let Instance::Attached((_, ch), space) = &mut body.body {
-			space
-				.map_mut(|space| {
-					for ch in ch.iter().filter_map(Option::as_ref) {
-						space
-							.colliders_mut()
-							.get_mut(*ch)
-							.expect("Invalid collider")
-							.set_collision_groups(cg);
-					}
-				})
-				.expect("Invalid space");
-		}
-	});
+	map_or_err!(body, map_body_mut, |body, _| body.set_mask(mask as u16));
 }
 
 fn set_mode(body: Index, mode: i32) {
@@ -746,209 +287,54 @@ fn set_mode(body: Index, mode: i32) {
 					return;
 				}
 			};
-			map_or_err!(body, map_body_mut, |body, _| {
-				match &mut body.body {
-					Instance::Attached((rb, _), space) => {
-						space
-							.map_mut(|s| {
-								s.bodies_mut()
-									.get_mut(*rb)
-									.expect("Invalid body handle")
-									.set_body_status(mode)
-							})
-							.expect("Invalid space");
-					}
-					Instance::Loose(body) => {
-						body.set_body_status(mode);
-					}
-				}
-			});
+			map_or_err!(body, map_body_mut, |body, _| body.set_body_status(mode));
 		}
 		Err(_) => godot_error!("Invalid mode"),
 	}
 }
 
 fn set_omit_force_integration(body: Index, enable: bool) {
-	map_or_err!(body, map_body_mut, |body, _| {
-		if body.omit_force_integration != enable {
-			body.omit_force_integration = enable;
-			let g_scale = if enable { 0.0 } else { 1.0 };
-			match &mut body.body {
-				Instance::Attached((rb, _), space) => {
-					space
-						.map_mut(|space| {
-							space
-								.bodies_mut()
-								.get_mut(*rb)
-								.expect("Invalid body handle")
-								.set_gravity_scale(g_scale, true);
-						})
-						.expect("Invalid space");
-				}
-				Instance::Loose(body) => {
-					body.set_gravity_scale(g_scale, true);
-				}
-			}
-		}
-	});
+	map_or_err!(body, map_body_mut, |body, _| body.set_omit_force_integration(enable));
 }
 
 fn set_shape_transform(body: Index, shape: i32, transform: &Transform) {
 	let shape = shape as u32;
-	map_or_err!(body, map_body_mut, |v, _| v.map_shape_mut(shape, |v| (
-		v.transform,
-		v.scale
-	) =
-		transform_to_isometry_and_scale(transform)));
+	map_or_err!(body, map_body_mut, |body, _| body.set_shape_transform(shape, transform, true));
 }
 
 fn set_shape_disabled(body: Index, shape: i32, disable: bool) {
-	let shape = shape as u32;
-	map_or_err!(body, map_body_mut, |v, _| v
-		.map_shape_mut(shape, |v| v.enabled = !disable));
+	map_or_err!(body, map_body_mut, |body, _| body.set_shape_enable(shape as u32, !disable));
 }
 
 fn set_space(body: Index, space: Option<Index>) {
-	if let Some(space) = space {
-		if let Index::Space(space) = space {
-			let colliders = body
-				.map_body(|body, index| body.create_colliders(index))
-				.expect("Body is invalid");
-			map_or_err!(body, map_body_mut, |body, body_index| {
-				// FIXME remove exceptions
-				let b = Instance::Attached((RigidBodyHandle::invalid(), Vec::new()), space);
-				body.recalculate_inertia();
-				let b = mem::replace(&mut body.body, b);
-				body.body = match b {
-					Instance::Attached(_, _) => todo!(),
-					Instance::Loose(b) => {
-						let mut collider_handles = Vec::with_capacity(colliders.len());
-						let handle = space
-							.map_mut(|space| {
-								let mp = *b.mass_properties();
-								let handle = space.add_body(b);
-								for collider in colliders {
-									let handle = collider.map(|c| space.add_collider(c, handle));
-									collider_handles.push(handle);
-								}
-								for &exclude in body.exclusions.iter() {
-									// "Adding" an exclusion multiple times is valid
-									let _ = space.add_body_exclusion(body_index, exclude);
-								}
-								space
-									.bodies_mut()
-									.get_mut(handle)
-									.unwrap()
-									.set_mass_properties(mp, false);
-								handle
-							})
-							.expect("Invalid space");
-						Instance::Attached((handle, collider_handles), space)
-					}
-				};
-			});
+	map_or_err!(body, map_body_mut, |body, _| {
+		if let Some(space) = space {
+			map_or_err!(space, map_space_mut, |space, _| body.set_space(space));
+		} else {
+			body.remove_from_space();
 		}
-	} else {
-		// FIXME remove exceptions
-		map_or_err!(body, map_body_mut, |body, _| {
-			let rb = match body.body {
-				Instance::Attached((body, _), space) => space
-					.map_mut(|space| space.remove_body(body))
-					.expect("Failed to modify space")
-					.expect("Invalid body handle"),
-				Instance::Loose(_) => todo!(),
-			};
-			body.body = Instance::Loose(rb);
-		});
-	}
+	});
 }
 
 fn set_ray_pickable(body: Index, enable: bool) {
-	// TODO IIRC there is no equivalent in Rapier3D, unless I misunderstand the purpose of this function
-	let _ = (body, enable);
+	map_or_err!(body, map_body_mut, |body, _| body.set_ray_pickable(enable));
 }
 
 fn set_state(body: Index, state: i32, value: &Variant) {
-	let apply = |scale: &mut _, body: &mut RigidBody, state| match state {
-		State::Transform(trf) => {
-			let (iso, scl) = transform_to_isometry_and_scale(&trf);
-			body.set_position(iso, true);
-			*scale = scl;
-		}
-		State::LinearVelocity(vel) => body.set_linvel(vec_gd_to_na(vel), true),
-		State::AngularVelocity(vel) => body.set_angvel(vec_gd_to_na(vel), true),
-		State::Sleeping(sleep) => body.activation.sleeping = sleep,
-		State::CanSleep(sleep) => {
-			body.activation.threshold = if sleep {
-				ActivationStatus::default_threshold()
-			} else {
-				-1.0
-			}
-		}
-	};
-
 	map_or_err!(body, map_body_mut, |body, _| {
-		let mut scale = body.scale;
-		let mut scale_changed = false;
 		match State::new(state, value) {
-			Ok(state) => match &mut body.body {
-				Instance::Attached((rb, _), space) => {
-					let old_scale = scale;
-					space
-						.map_mut(|space| {
-							apply(
-								&mut scale,
-								space
-									.bodies_mut()
-									.get_mut(*rb)
-									.expect("Invalid body handle"),
-								state,
-							)
-						})
-						.expect("Invalid body or space");
-					if (old_scale.x - scale.x).abs() > 1e-6
-						|| (old_scale.y - scale.y).abs() > 1e-6
-						|| (old_scale.z - scale.z).abs() > 1e-6
-					{
-						scale_changed = true;
-						body.scale = scale;
-					}
-				}
-				Instance::Loose(rb) => {
-					apply(&mut scale, rb, state);
-					body.scale = scale;
-				}
+			Ok(state) => match state {
+				State::Transform(trf) => body.set_transform(&trf),
+				State::LinearVelocity(vel) => body.set_linear_velocity(vel),
+				State::AngularVelocity(vel) => body.set_angular_velocity(vel),
+				State::Sleeping(sleep) => body.set_sleeping(sleep),
+				State::CanSleep(sleep) => body.set_sleep_threshold(if sleep {
+					ActivationStatus::default_threshold()
+				} else {
+					-1.0
+				}),
 			},
 			Err(e) => godot_error!("Invalid state: {:?}", e),
-		}
-
-		// Scaling shapes is potentially very expensive, so avoid it when possible
-		// is_equal_approx (not implemented yet) should be close enough
-		if scale_changed {
-			let shapes = body
-				.create_shapes()
-				.into_iter()
-				.map(|v| v.map(|v| v.0))
-				.collect::<Vec<_>>();
-			if let Instance::Attached((_, colliders), space) = &mut body.body {
-				space
-					.map_mut(|space| {
-						let iter = colliders.iter().zip(shapes.into_iter());
-						for (&handle, shape) in iter {
-							if let Some(handle) = handle {
-								space
-									.colliders_mut()
-									.get_mut(handle)
-									.expect("Invalid collider handle")
-									.set_shape(shape.expect("No shape"));
-							}
-						}
-					})
-					.expect("Invalid space");
-			} else {
-				unreachable!();
-			}
-			body.recalculate_inertia();
 		}
 	});
 }
@@ -956,13 +342,9 @@ fn set_state(body: Index, state: i32, value: &Variant) {
 /// Godot's "It's local position but global rotation" is such a mindfuck that this function exists
 /// to help out
 fn transform_force_arguments(
-	body: &RigidBody,
+	body: &Body,
 	position: &Vector3,
 	direction: &Vector3,
-) -> (na::Point3<f32>, na::Vector3<f32>) {
-	let position = na::Point3::new(position.x, position.y, position.z);
-	let tr = body.position().translation;
-	let position = position + na::Vector3::new(tr.x, tr.y, tr.z);
-	let direction = vec_gd_to_na(*direction);
-	(position, direction)
+) -> (Vector3, Vector3) {
+	(*position + body.translation(), *direction)
 }

--- a/rapier3d/src/server/ffi.rs
+++ b/rapier3d/src/server/ffi.rs
@@ -15,6 +15,7 @@ use gdnative::sys;
 use std::slice;
 
 pub type PhysicsBodyState = physics_body_state;
+pub type PhysicsBodyContact = physics_body_contact;
 pub type PhysicsAreaMonitorEvent = physics_area_monitor_event;
 pub type PhysicsRayResult = physics_ray_result;
 pub type PhysicsRayInfo = physics_ray_info;
@@ -103,6 +104,44 @@ impl PhysicsBodyState {
 
 	pub fn set_center_of_mass(&mut self, center: Vector3) {
 		self.center_of_mass = center.to_sys();
+	}
+
+	pub fn set_contact_count(&mut self, count: u32) {
+		self.contact_count = count;
+	}
+}
+
+impl PhysicsBodyContact {
+	pub fn set_index(&mut self, index: Index) {
+		self.index = index.raw();
+	}
+
+	pub fn set_position(&mut self, position: Vector3) {
+		self.position = position.to_sys();
+	}
+
+	pub fn set_object_id(&mut self, id: Option<ObjectID>) {
+		self.object_id = id.map(ObjectID::get).unwrap_or(0) as i32;
+	}
+
+	pub fn set_shape(&mut self, shape: u32) {
+		self.shape = shape;
+	}
+
+	pub fn set_local_position(&mut self, position: Vector3) {
+		self.local_position = position.to_sys();
+	}
+
+	pub fn set_local_normal(&mut self, normal: Vector3) {
+		self.local_normal = normal.to_sys();
+	}
+
+	pub fn set_local_shape(&mut self, shape: u32) {
+		self.local_shape = shape;
+	}
+
+	pub fn set_impulse(&mut self, impulse: f32) {
+		self.impulse = impulse;
 	}
 }
 

--- a/rapier3d/src/server/index.rs
+++ b/rapier3d/src/server/index.rs
@@ -1,3 +1,5 @@
+use crate::indices;
+
 pub const AREA_ID: u8 = 1;
 pub const BODY_ID: u8 = 2;
 pub const JOINT_ID: u8 = 3;
@@ -151,23 +153,22 @@ macro_rules! generate {
 			}
 		}
 
-		impl Into<crate::indices::Index> for $index {
+		impl From<$index> for indices::Index {
 			/// Converts a [`$index`] into a [`Index`](crate::indices::Index)
-			fn into(self) -> crate::indices::Index {
-				crate::indices::Index::new(self.0, self.1)
+			fn from(index: $index) -> Self {
+				Self::new(index.0, index.1)
 			}
 		}
 
-		impl Into<crate::indices::Index> for &$index {
-			/// Converts a [`$index`] into a [`Index`](crate::indices::Index)
-			fn into(self) -> crate::indices::Index {
-				(*self).into()
+		impl From<&$index> for indices::Index {
+			fn from(index: &$index) -> Self {
+				(*index).into()
 			}
 		}
 
-		impl From<crate::indices::Index> for $index {
+		impl From<indices::Index> for $index {
 			/// Converts a [`$index`] into a [`Index`](crate::indices::Index)
-			fn from(index: crate::indices::Index) -> Self {
+			fn from(index: indices::Index) -> Self {
 				Self(index.index(), index.generation())
 			}
 		}

--- a/rapier3d/src/server/joint.rs
+++ b/rapier3d/src/server/joint.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::body::{self, Body};
+use crate::body;
 use crate::util::*;
 use core::convert::TryFrom;
 use gdnative::core_types::*;

--- a/rapier3d/src/server/joint.rs
+++ b/rapier3d/src/server/joint.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::body::Body;
 use crate::util::*;
 use gdnative::core_types::*;
 use gdnative::godot_error;

--- a/rapier3d/src/server/joint.rs
+++ b/rapier3d/src/server/joint.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::body::Body;
+use crate::body::{self, Body};
 use crate::util::*;
+use core::convert::TryFrom;
 use gdnative::core_types::*;
 use gdnative::godot_error;
 use rapier3d::dynamics::{JointHandle, JointParams, RevoluteJoint, SpringModel};
@@ -197,8 +198,8 @@ fn disable_collisions_between_bodies(joint: Index, disable: bool) {
 					// for the cleanest way to handle this (should the joint be freed?)
 					let a = space.bodies().get(joint.body1).expect("Invalid body A");
 					let b = space.bodies().get(joint.body2).expect("Invalid body B");
-					let a = Body::get_index(a);
-					let b = Body::get_index(b);
+					let a = body::RigidBodyUserdata::try_from(a).unwrap().index();
+					let b = body::RigidBodyUserdata::try_from(b).unwrap().index();
 					let result = if enable {
 						space.add_body_exclusion(a, b)
 					} else {

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -8,16 +8,16 @@ mod shape;
 mod space;
 
 use crate::area::Area;
-use crate::space::Space;
+use crate::body::Body;
 use crate::indices::Indices;
+use crate::space::Space;
 use crate::*;
-pub use body::Body;
 use core::num::NonZeroU32;
 use gdnative::godot_error;
 pub use index::*;
 use joint::Joint;
 use rapier3d::na;
-use shape::Shape;
+pub use shape::Shape;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 lazy_static::lazy_static! {

--- a/rapier3d/src/space.rs
+++ b/rapier3d/src/space.rs
@@ -1,5 +1,5 @@
 use crate::area::Area;
-use crate::body::{self, Body};
+use crate::body;
 use crate::server::{AreaIndex, BodyIndex, MapIndex, ShapeIndex, SpaceIndex};
 use crate::util::*;
 use core::convert::TryFrom;
@@ -15,8 +15,8 @@ use rapier3d::geometry::{
 };
 use rapier3d::na::Point3;
 use rapier3d::pipeline::{
-	ChannelEventCollector, ContactModificationContext, EventHandler, PairFilterContext,
-	PhysicsHooks, PhysicsHooksFlags, PhysicsPipeline, QueryPipeline,
+	ContactModificationContext, EventHandler, PairFilterContext, PhysicsHooks, PhysicsHooksFlags,
+	PhysicsPipeline, QueryPipeline,
 };
 use std::collections::BTreeMap;
 

--- a/test/contact/box_on_box.tscn
+++ b/test/contact/box_on_box.tscn
@@ -1,0 +1,68 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://addons/3d_batcher/batched_mesh_instance.gdns" type="Script" id=1]
+[ext_resource path="res://test/contact/color_contact.gd" type="Script" id=2]
+[ext_resource path="res://benchmark/bodies/material.tres" type="Material" id=3]
+
+[sub_resource type="BoxShape" id=1]
+extents = Vector3( 4, 1, 4 )
+
+[sub_resource type="CubeMesh" id=2]
+material = ExtResource( 3 )
+size = Vector3( 8, 2, 8 )
+
+[sub_resource type="BoxShape" id=3]
+
+[sub_resource type="CubeMesh" id=4]
+material = ExtResource( 3 )
+
+[node name="Box on box" type="Node"]
+
+[node name="StaticBody" type="StaticBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="0" type="CollisionShape" parent="StaticBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -5, 0 )
+shape = SubResource( 1 )
+
+[node name="1" type="CollisionShape" parent="StaticBody"]
+shape = SubResource( 1 )
+
+[node name="Mesh" type="Spatial" parent="StaticBody"]
+script = ExtResource( 1 )
+mesh = SubResource( 2 )
+use_color = true
+color = Color( 1, 1, 1, 1 )
+
+[node name="RigidBody" type="RigidBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0 )
+contacts_reported = 8
+contact_monitor = true
+can_sleep = false
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="0" type="CollisionShape" parent="RigidBody"]
+shape = SubResource( 3 )
+
+[node name="Mesh" type="Spatial" parent="RigidBody"]
+script = ExtResource( 1 )
+mesh = SubResource( 4 )
+use_color = true
+color = Color( 1, 1, 1, 1 )
+
+[node name="Timer" type="Timer" parent="RigidBody"]
+process_mode = 0
+wait_time = 2.5
+autostart = true
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 12 )
+[connection signal="body_entered" from="RigidBody" to="RigidBody" method="enter"]
+[connection signal="body_exited" from="RigidBody" to="RigidBody" method="exit"]
+[connection signal="timeout" from="RigidBody/Timer" to="RigidBody" method="set_translation" binds= [ Vector3( 0, 3, 0 ) ]]

--- a/test/contact/color_contact.gd
+++ b/test/contact/color_contact.gd
@@ -1,0 +1,26 @@
+extends RigidBody
+
+var node_count := 0
+
+func enter(n):
+	node_count += 1
+	get_node("Mesh").color = Color.red
+
+
+func exit(n):
+	get_node("Mesh").color = Color.green
+	node_count -= 1
+
+
+func _integrate_forces(state):
+	print("Node count: ", node_count)
+	print("Contact count: ", state.get_contact_count())
+	for i in state.get_contact_count():
+		var pos = state.get_contact_collider_position(i)
+		var pos_l = state.get_contact_local_position(i)
+		var norm_l = state.get_contact_local_normal(i)
+		var shape_self = state.get_contact_local_shape(i)
+		var shape_other = state.get_contact_collider_shape(i)
+		var other = state.get_contact_collider_object(i)
+		print("GLOBAL POS  ", pos, "  |  LOCAL POS  ", pos_l, "  |  LOCAL NORMAL  ", norm_l, "  |  SHAPES  ", shape_self, " ", shape_other, "  |  OBJECT  ", other)
+	print()

--- a/test/ffi/box.tscn
+++ b/test/ffi/box.tscn
@@ -1,6 +1,0 @@
-[gd_scene format=2]
-
-[node name="Node" type="Node"]
-
-[node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 24 )


### PR DESCRIPTION
`get_contact_collider_velocity_at_position` and `get_contact_impulse` aren't yet implemented as it's not clear to me what exact values they are supposed to have (hell, even `get_contact_collider_position` is ill-defined apparently).

The behaviour differs from Bullet in that it returns all contacts instead of just one. It also differs from `GodotPhysics` in that `get_contact_collider_position` doesn't return coordinates in a random local space. Since Bullet is the least broken, I used that as reference.