### PR TITLE
Use macro to register FFI function to remove indirection

### DIFF
--- a/rapier3d/src/server/area.rs
+++ b/rapier3d/src/server/area.rs
@@ -43,31 +43,31 @@ impl Param {
 }
 
 pub fn init(ffi: &mut ffi::FFI) {
-	ffi.area_add_shape(add_shape);
-	ffi.area_attach_object_instance_id(attach_object_instance_id);
-	ffi.area_clear_shapes(clear_shapes);
-	ffi.area_create(create);
-	ffi.area_get_area_event(get_area_event);
-	ffi.area_get_body_event(get_body_event);
-	ffi.area_get_object_instance_id(get_object_instance_id);
-	ffi.area_get_shape(get_shape);
-	ffi.area_get_shape_transform(get_shape_transform);
-	ffi.area_get_space(get_space);
-	ffi.area_get_space_override_mode(get_space_override_mode);
-	ffi.area_get_transform(get_transform);
-	ffi.area_is_ray_pickable(is_ray_pickable);
-	ffi.area_remove_shape(remove_shape);
-	ffi.area_set_collision_layer(set_collision_layer);
-	ffi.area_set_collision_mask(set_collision_mask);
-	ffi.area_set_monitorable(set_monitorable);
-	ffi.area_set_param(set_param);
-	ffi.area_set_ray_pickable(set_ray_pickable);
-	ffi.area_set_shape(set_shape);
-	ffi.area_set_shape_disabled(set_shape_disabled);
-	ffi.area_set_shape_transform(set_shape_transform);
-	ffi.area_set_space(set_space);
-	ffi.area_set_space_override_mode(set_space_override_mode);
-	ffi.area_set_transform(set_transform);
+	ffi!(ffi, area_add_shape, add_shape);
+	ffi!(ffi, area_attach_object_instance_id, attach_object_instance_id);
+	ffi!(ffi, area_clear_shapes, clear_shapes);
+	ffi!(ffi, area_create, create);
+	ffi!(ffi, area_get_area_event, get_area_event);
+	ffi!(ffi, area_get_body_event, get_body_event);
+	ffi!(ffi, area_get_object_instance_id, get_object_instance_id);
+	ffi!(ffi, area_get_shape, get_shape);
+	ffi!(ffi, area_get_shape_transform, get_shape_transform);
+	ffi!(ffi, area_get_space, get_space);
+	ffi!(ffi, area_get_space_override_mode, get_space_override_mode);
+	ffi!(ffi, area_get_transform, get_transform);
+	ffi!(ffi, area_is_ray_pickable, is_ray_pickable);
+	ffi!(ffi, area_remove_shape, remove_shape);
+	ffi!(ffi, area_set_collision_layer, set_collision_layer);
+	ffi!(ffi, area_set_collision_mask, set_collision_mask);
+	ffi!(ffi, area_set_monitorable, set_monitorable);
+	ffi!(ffi, area_set_param, set_param);
+	ffi!(ffi, area_set_ray_pickable, set_ray_pickable);
+	ffi!(ffi, area_set_shape, set_shape);
+	ffi!(ffi, area_set_shape_disabled, set_shape_disabled);
+	ffi!(ffi, area_set_shape_transform, set_shape_transform);
+	ffi!(ffi, area_set_space, set_space);
+	ffi!(ffi, area_set_space_override_mode, set_space_override_mode);
+	ffi!(ffi, area_set_transform, set_transform);
 }
 
 pub fn free(_area: Area) {

--- a/rapier3d/src/server/body.rs
+++ b/rapier3d/src/server/body.rs
@@ -113,28 +113,28 @@ impl Mode {
 }
 
 pub fn init(ffi: &mut ffi::FFI) {
-	ffi.body_add_force(add_force);
-	ffi.body_add_shape(add_shape);
-	ffi.body_add_collision_exception(add_collision_exception);
-	ffi.body_apply_impulse(apply_impulse);
-	ffi.body_attach_object_instance_id(attach_object_instance_id);
-	ffi.body_create(create);
-	ffi.body_get_contact(get_contact);
-	ffi.body_get_direct_state(get_direct_state);
-	ffi.body_get_kinematic_safe_margin(|_| 0.0);
-	ffi.body_remove_shape(remove_shape);
-	ffi.body_set_collision_layer(set_collision_layer);
-	ffi.body_set_collision_mask(set_collision_mask);
-	ffi.body_set_kinematic_safe_margin(|_, _| ());
-	ffi.body_set_max_contacts_reported(set_max_contacts_reported);
-	ffi.body_set_mode(set_mode);
-	ffi.body_set_omit_force_integration(set_omit_force_integration);
-	ffi.body_set_param(set_param);
-	ffi.body_set_shape_transform(set_shape_transform);
-	ffi.body_set_shape_disabled(set_shape_disabled);
-	ffi.body_set_space(set_space);
-	ffi.body_set_state(set_state);
-	ffi.body_set_ray_pickable(set_ray_pickable);
+	ffi!(ffi, body_add_force, add_force);
+	ffi!(ffi, body_add_shape, add_shape);
+	ffi!(ffi, body_add_collision_exception, add_collision_exception);
+	ffi!(ffi, body_apply_impulse, apply_impulse);
+	ffi!(ffi, body_attach_object_instance_id, attach_object_instance_id);
+	ffi!(ffi, body_create, create);
+	ffi!(ffi, body_get_contact, get_contact);
+	ffi!(ffi, body_get_direct_state, get_direct_state);
+	ffi!(ffi, body_get_kinematic_safe_margin, |_| 0.0);
+	ffi!(ffi, body_remove_shape, remove_shape);
+	ffi!(ffi, body_set_collision_layer, set_collision_layer);
+	ffi!(ffi, body_set_collision_mask, set_collision_mask);
+	ffi!(ffi, body_set_kinematic_safe_margin, |_, _| ());
+	ffi!(ffi, body_set_max_contacts_reported, set_max_contacts_reported);
+	ffi!(ffi, body_set_mode, set_mode);
+	ffi!(ffi, body_set_omit_force_integration, set_omit_force_integration);
+	ffi!(ffi, body_set_param, set_param);
+	ffi!(ffi, body_set_shape_transform, set_shape_transform);
+	ffi!(ffi, body_set_shape_disabled, set_shape_disabled);
+	ffi!(ffi, body_set_space, set_space);
+	ffi!(ffi, body_set_state, set_state);
+	ffi!(ffi, body_set_ray_pickable, set_ray_pickable);
 }
 
 /// Frees the given body, removing it from it's attached space (if any)

--- a/rapier3d/src/server/ffi.rs
+++ b/rapier3d/src/server/ffi.rs
@@ -36,7 +36,7 @@ macro_rules! gdphysics_init {
 }
 
 pub struct FFI {
-	table: *mut UnsafeApi,
+	pub table: *mut UnsafeApi,
 }
 
 use super::Index;

--- a/rapier3d/src/server/joint.rs
+++ b/rapier3d/src/server/joint.rs
@@ -125,12 +125,12 @@ impl HingeFlag {
 }
 
 pub fn init(ffi: &mut ffi::FFI) {
-	ffi.joint_create_hinge(create_hinge);
-	ffi.joint_disable_collisions_between_bodies(disable_collisions_between_bodies);
-	ffi.joint_get_solver_priority(|_| 0);
-	ffi.joint_set_solver_priority(|_, _| {});
-	ffi.hinge_joint_set_flag(set_hinge_flag);
-	ffi.hinge_joint_set_param(set_hinge_param);
+	ffi!(ffi, joint_create_hinge, create_hinge);
+	ffi!(ffi, joint_disable_collisions_between_bodies, disable_collisions_between_bodies);
+	ffi!(ffi, joint_get_solver_priority, |_| 0);
+	ffi!(ffi, joint_set_solver_priority, |_, _| {});
+	ffi!(ffi, hinge_joint_set_flag, set_hinge_flag);
+	ffi!(ffi, hinge_joint_set_param, set_hinge_param);
 }
 
 /// Frees the given hinge, removing it from it's attached bodies (if any)

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -237,13 +237,13 @@ macro_rules! map_or_err {
 }
 
 fn init(ffi: &mut ffi::FFI) {
-	ffi.set_active(set_active);
-	ffi.init(server_init);
-	ffi.flush_queries(flush_queries);
-	ffi.step(step);
-	ffi.sync(sync);
-	ffi.free(free);
-	ffi.get_process_info(get_process_info);
+	ffi!(ffi, set_active, set_active);
+	ffi!(ffi, init, server_init);
+	ffi!(ffi, flush_queries, flush_queries);
+	ffi!(ffi, step, step);
+	ffi!(ffi, sync, sync);
+	ffi!(ffi, free, free);
+	ffi!(ffi, get_process_info, get_process_info);
 	area::init(ffi);
 	body::init(ffi);
 	joint::init(ffi);

--- a/rapier3d/src/server/shape.rs
+++ b/rapier3d/src/server/shape.rs
@@ -272,10 +272,10 @@ impl Shape {
 }
 
 pub fn init(ffi: &mut ffi::FFI) {
-	ffi.shape_create(create);
-	ffi.shape_get_margin(|_| 0.0);
-	ffi.shape_set_margin(|_, _| ());
-	ffi.shape_set_data(set_data);
+	ffi!(ffi, shape_create, create);
+	ffi!(ffi, shape_get_margin, |_| 0.0);
+	ffi!(ffi, shape_set_margin, |_, _| ());
+	ffi!(ffi, shape_set_data, set_data);
 }
 
 /// Frees the given shape, removing it from any attached rigidbodies

--- a/rapier3d/src/server/space.rs
+++ b/rapier3d/src/server/space.rs
@@ -2,10 +2,10 @@ use super::*;
 use crate::space::Space;
 
 pub fn init(ffi: &mut ffi::FFI) {
-	ffi.space_create(create);
-	ffi.space_is_active(is_active);
-	ffi.space_set_active(set_active);
-	ffi.space_intersect_ray(intersect_ray);
+	ffi!(ffi, space_create, create);
+	ffi!(ffi, space_is_active, is_active);
+	ffi!(ffi, space_set_active, set_active);
+	ffi!(ffi, space_intersect_ray, intersect_ray);
 }
 
 pub fn free(_space: Space) {}


### PR DESCRIPTION
To test it, I inserted a `panic!()` in the `step` function

Before this change, you'd get this:

```
stack backtrace:
   0: std::panicking::begin_panic
   1: godot_rapier3d::server::step
   2: godot_rapier3d::server::ffi::FFI::step::wrap
   3: _ZN22PluggablePhysicsServer4stepEf
             at /home/david/Documents/godot/godot-stable/modules/pluggable_physics/server.cpp:70:2
   4: _ZN4Main9iterationEv
             at /home/david/Documents/godot/godot-stable/main/main.cpp:2094:39
   5: _ZN6OS_X113runEv
             at /home/david/Documents/godot/godot-stable/platform/x11/os_x11.cpp:3233:22
   6: main
             at /home/david/Documents/godot/godot-stable/platform/x11/godot_x11.cpp:56:9
   7: __libc_start_main
   8: _start
```

Now, you get this:

```
thread '<unnamed>' panicked at 'explicit panic', rapier3d/src/server/mod.rs:259:5
stack backtrace:
   0: std::panicking::begin_panic
   1: godot_rapier3d::server::init::ffi_step
   2: _ZN22PluggablePhysicsServer4stepEf
             at /home/david/Documents/godot/godot-stable/modules/pluggable_physics/server.cpp:70:2
   3: _ZN4Main9iterationEv
             at /home/david/Documents/godot/godot-stable/main/main.cpp:2094:39
   4: _ZN6OS_X113runEv
             at /home/david/Documents/godot/godot-stable/platform/x11/os_x11.cpp:3233:22
   5: main
             at /home/david/Documents/godot/godot-stable/platform/x11/godot_x11.cpp:56:9
   6: __libc_start_main
   7: _start
```

There is one less frame, which means the wrapped function got inlined. Hopefully this also allows some more optimizitations when it comes to type conversions.