### PR TITLE
Expose step method to GDScript

### DIFF
--- a/module/server.cpp
+++ b/module/server.cpp
@@ -22,7 +22,7 @@ PluggablePhysicsServer::~PluggablePhysicsServer() {
 }
 
 void PluggablePhysicsServer::_bind_methods() {
-
+	ClassDB::bind_method(D_METHOD("step", "delta"), &PluggablePhysicsServer::step);
 }
 
 void PluggablePhysicsServer::area_set_monitor_callback(RID area, Object* receiver, const StringName &method) {

--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,14 @@ enabled=PoolStringArray( "3d_batcher" )
 
 singletons=[  ]
 
+[input]
+
+advance_simulation={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
 [physics]
 
 3d/physics_engine="Custom"

--- a/test/step/manual.gd
+++ b/test/step/manual.gd
@@ -1,0 +1,13 @@
+extends Node
+
+
+func _ready():
+	PhysicsServer.set_active(false)
+	print("Press 'Space' to advance the simulation")
+
+
+func _input(event):
+	if event.is_action_pressed("advance_simulation"):
+		PhysicsServer.set_active(true)
+		PhysicsServer.step(1 / 30.0)
+		PhysicsServer.set_active(false)

--- a/test/step/manual.tscn
+++ b/test/step/manual.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://test/step/manual.gd" type="Script" id=1]
+
+[sub_resource type="PhysicsMaterial" id=1]
+bounce = 1.0
+
+[sub_resource type="BoxShape" id=2]
+
+[sub_resource type="CubeMesh" id=3]
+
+[sub_resource type="PhysicsMaterial" id=4]
+bounce = 1.0
+
+[sub_resource type="BoxShape" id=5]
+extents = Vector3( 10.8484, 1, 7.00351 )
+
+[node name="Manual step" type="Node"]
+script = ExtResource( 1 )
+
+[node name="RigidBody" type="RigidBody" parent="."]
+physics_material_override = SubResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="RigidBody"]
+shape = SubResource( 2 )
+
+[node name="MeshInstance" type="MeshInstance" parent="RigidBody"]
+mesh = SubResource( 3 )
+material/0 = null
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 8, 18 )
+
+[node name="StaticBody" type="StaticBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -4, 0 )
+physics_material_override = SubResource( 4 )
+
+[node name="CollisionShape" type="CollisionShape" parent="StaticBody"]
+shape = SubResource( 5 )


### PR DESCRIPTION
This allows implementing physics rollback in GDScript.

This partially addresses #20. The determinism part needs to be looked at and perhaps implemented in a separate patch.