### PR TITLE
Fix body_get_direct_state not setting body state if outside space.

### DIFF
--- a/rapier3d/src/server/body.rs
+++ b/rapier3d/src/server/body.rs
@@ -256,22 +256,20 @@ fn attach_object_instance_id(body: Index, id: u32) {
 fn get_direct_state(body: Index, state: &mut ffi::PhysicsBodyState) {
 	map_or_err!(body, map_body, |body, _| {
 		body.read_body(|rb, space| {
-			if let Some(space) = space {
-				state.set_transform(&isometry_to_transform(rb.position()));
-				state.set_space(Index::Space(space));
-				state.set_linear_velocity(vec_na_to_gd(*rb.linvel()));
-				state.set_angular_velocity(vec_na_to_gd(*rb.angvel()));
-				state.set_sleeping(rb.is_sleeping());
-				state.set_linear_damp(rb.linear_damping);
-				state.set_angular_damp(rb.angular_damping);
-				let mp = rb.mass_properties();
-				state.set_inv_mass(mp.inv_mass);
-				let inv_inertia_sqrt = vec_na_to_gd(mp.inv_principal_inertia_sqrt);
-				state.set_inv_inertia(inv_inertia_sqrt.component_mul(inv_inertia_sqrt));
-				let inv_inertia_tensor = mp.reconstruct_inverse_inertia_matrix();
-				state.set_inv_inertia_tensor(&mat3_to_basis(&inv_inertia_tensor));
-				state.set_contact_count(body.contact_count());
-			}
+			state.set_transform(&isometry_to_transform(rb.position()));
+			state.set_linear_velocity(vec_na_to_gd(*rb.linvel()));
+			state.set_angular_velocity(vec_na_to_gd(*rb.angvel()));
+			state.set_sleeping(rb.is_sleeping());
+			state.set_linear_damp(rb.linear_damping);
+			state.set_angular_damp(rb.angular_damping);
+			let mp = rb.mass_properties();
+			state.set_inv_mass(mp.inv_mass);
+			let inv_inertia_sqrt = vec_na_to_gd(mp.inv_principal_inertia_sqrt);
+			state.set_inv_inertia(inv_inertia_sqrt.component_mul(inv_inertia_sqrt));
+			let inv_inertia_tensor = mp.reconstruct_inverse_inertia_matrix();
+			state.set_inv_inertia_tensor(&mat3_to_basis(&inv_inertia_tensor));
+			state.set_contact_count(body.contact_count());
+			state.set_space(space.map(Index::Space));
 		});
 	});
 }

--- a/rapier3d/src/server/ffi.rs
+++ b/rapier3d/src/server/ffi.rs
@@ -48,8 +48,8 @@ impl FFI {
 }
 
 impl PhysicsBodyState {
-	pub fn set_space(&mut self, index: Index) {
-		self.space = index.raw();
+	pub fn set_space(&mut self, index: Option<Index>) {
+		self.space = index.map(Index::raw).unwrap_or(Index::INVALID_RAW);
 	}
 
 	pub fn set_transform(&mut self, transform: &Transform) {

--- a/rapier3d/src/server/index.rs
+++ b/rapier3d/src/server/index.rs
@@ -106,7 +106,7 @@ impl SpaceIndex {
 impl Index {
 	/// A value that represents an invalid index as a u64.
 	#[allow(unused)]
-	const INVALID_RAW: u64 = 0;
+	pub const INVALID_RAW: u64 = 0;
 
 	/// Converts an Index into an u64
 	pub fn raw(self) -> u64 {

--- a/test/scene_switch/a.tscn
+++ b/test/scene_switch/a.tscn
@@ -5,13 +5,13 @@
 [node name="Switch scene A" type="Node"]
 
 [node name="RigidBody" parent="." instance=ExtResource( 1 )]
-transform = Transform( 0, 0, 1, 0, 1, 0, -1, 0, 0, 0, 0, 7 )
+transform = Transform( 0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, -13, 0, 1 )
 
 [node name="RigidBody2" parent="." instance=ExtResource( 1 )]
 transform = Transform( 0, 0, 1, 0, 1, 0, -1, 0, 0, 0, 0, 7 )
 
 [node name="RigidBody3" parent="." instance=ExtResource( 1 )]
-transform = Transform( 0.0500843, 0.976356, -0.210287, -0.977322, 0.00453573, -0.211711, -0.205751, 0.216122, 0.954441, 0, 0, -8 )
+transform = Transform( 0.0500842, 0.976356, -0.210288, -0.977322, 0.0045355, -0.211711, -0.205751, 0.216122, 0.954441, 0, 0, -8 )
 
 [node name="RigidBody4" parent="." instance=ExtResource( 1 )]
 transform = Transform( -0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, -0.965926, 10, 0, 7 )


### PR DESCRIPTION
When a body was not attached to any space it would not write out any
data to the body state singleton. This was silent and resulted in
objects copying the transform of whatever object was last in a space and
got its state fetched.

Closes #24