### PR TITLE
Implement intersect_shape

### DIFF
--- a/module/generate.py
+++ b/module/generate.py
@@ -111,6 +111,12 @@ API_CUSTOM_FUNCTIONS = {
         ('const struct physics_ray_info *', 'info'),
         ('struct physics_ray_result *', 'result'),
     ]),
+    'space_intersect_shape': ('size_t', [
+        ('index_t', 'space'),
+        ('const struct physics_shape_info *', 'info'),
+        ('struct physics_shape_result *', 'result'),
+        ('size_t', 'max_results'),
+    ]),
     'soft_body_get_collision_exception': ('index_t', [
         ('index_t', 'body'),
         ('int', 'index')
@@ -161,6 +167,21 @@ API_STRUCTS = {
     'physics_ray_result': [
         ('godot_vector3', 'position'),
         ('godot_vector3', 'normal'),
+        ('index_t', 'id'),
+        ('int', 'object_id'),
+        ('int', 'shape'),
+    ],
+    'physics_shape_info': [
+        ('index_t', 'shape'),
+        ('const godot_transform *', 'transform'),
+        ('const index_t *', 'exclude'),
+        ('size_t', 'exclude_count'),
+        ('size_t', 'max_results'),
+        ('uint32_t', 'collision_mask'),
+        ('bool', 'collide_with_bodies'),
+        ('bool', 'collide_with_areas'),
+    ],
+    'physics_shape_result': [
         ('index_t', 'id'),
         ('int', 'object_id'),
         ('int', 'shape'),

--- a/rapier3d/build.rs
+++ b/rapier3d/build.rs
@@ -172,13 +172,13 @@ fn map_type(t: &str) -> TokenStream {
 		}
 		_ if t.starts_with("godot_") => {
 			if let Some(t) = t.strip_suffix(" *") {
-				format!("&mut sys::{}", t).parse().unwrap()
+				format!("*mut sys::{}", t).parse().unwrap()
 			} else {
 				format!("sys::{}", t).parse().unwrap()
 			}
 		}
 		_ if t.starts_with("const godot_") && t.ends_with(" *") => {
-			format!("&sys::{}", &t["const ".len()..t.len() - " *".len()])
+			format!("*const sys::{}", &t["const ".len()..t.len() - " *".len()])
 				.parse()
 				.unwrap()
 		}

--- a/rapier3d/src/body.rs
+++ b/rapier3d/src/body.rs
@@ -6,13 +6,13 @@ use crate::space::Space;
 use crate::util::*;
 use core::convert::{TryFrom, TryInto};
 use gdnative::core_types::*;
-use rapier3d::prelude::*;
 use rapier3d::dynamics::{MassProperties, RigidBody, RigidBodyHandle, RigidBodySet, RigidBodyType};
 use rapier3d::geometry::{
 	Collider, ColliderBuilder, ColliderHandle, InteractionGroups, SharedShape,
 };
 use rapier3d::math::Isometry;
 use rapier3d::na::{self, Point3};
+use rapier3d::prelude::*;
 
 pub struct BodyShape {
 	index: ShapeIndex,
@@ -179,7 +179,9 @@ impl Body {
 						let shape_scale = vec_gd_to_na(self_scale).component_mul(&shape_scale);
 						let shape_scale = vec_na_to_gd(shape_scale);
 						let mut collider = shape.build(body_shape.transform, shape_scale, false);
-						collider.set_active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::MODIFY_SOLVER_CONTACTS);
+						collider.set_active_hooks(
+							ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::MODIFY_SOLVER_CONTACTS,
+						);
 						collider.set_active_events(ActiveEvents::INTERSECTION_EVENTS);
 						let collider = space.add_collider(collider, *rb);
 						colliders.push(Some(collider));
@@ -249,7 +251,9 @@ impl Body {
 					.collision_groups(self.collision_groups)
 					.restitution(self.restitution)
 					.friction(self.friction)
-					.active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::MODIFY_SOLVER_CONTACTS)
+					.active_hooks(
+						ActiveHooks::FILTER_CONTACT_PAIRS | ActiveHooks::MODIFY_SOLVER_CONTACTS,
+					)
 					.active_events(ActiveEvents::INTERSECTION_EVENTS)
 					.build();
 				collider.user_data = ColliderUserdata::new(

--- a/rapier3d/src/server/space.rs
+++ b/rapier3d/src/server/space.rs
@@ -7,6 +7,7 @@ pub fn init(ffi: &mut ffi::FFI) {
 	ffi!(ffi, space_get_contact, get_contact);
 	ffi!(ffi, space_get_contact_count, get_contact_count);
 	ffi!(ffi, space_intersect_ray, intersect_ray);
+	ffi!(ffi, space_intersect_shape, intersect_shape);
 	ffi!(ffi, space_is_active, is_active);
 	ffi!(ffi, space_set_active, set_active);
 	ffi!(ffi, space_set_debug_contacts, set_debug_contacts);
@@ -85,6 +86,81 @@ fn intersect_ray(
 			godot_error!("Invalid space index");
 			false
 		})
+}
+
+fn intersect_shape(
+	space: Index,
+	info: &ffi::PhysicsShapeInfo,
+	results: *mut ffi::PhysicsShapeResult,
+	max_results: usize,
+) -> usize {
+	// SAFETY: We'll have to trust the Godot side that the results array is large enough.
+	let results = unsafe { core::slice::from_raw_parts_mut(results, max_results) };
+	map_or_err!(space, map_space_mut, |space, _| {
+		let exclude_raw = info.exclude_raw();
+		let mut exclude_bodies = if info.collide_with_bodies() {
+			Some(Vec::with_capacity(exclude_raw.len()))
+		} else {
+			None
+		};
+		let mut exclude_areas = if info.collide_with_areas() {
+			Some(Vec::with_capacity(exclude_raw.len()))
+		} else {
+			None
+		};
+		for &e in exclude_raw {
+			if let Ok(i) = Index::from_raw(e) {
+				match i {
+					Index::Body(i) => {
+						exclude_bodies.as_mut().map(|v| v.push(i));
+					}
+					Index::Area(i) => {
+						exclude_areas.as_mut().map(|v| v.push(i));
+					}
+					_ => godot_error!("One of the indices does not point to a body"),
+				}
+			} else {
+				godot_error!("One of the indices is invalid");
+			}
+		}
+
+		info.shape()
+			.map_err(|e| godot_error!("Invalid shape index: {:?}", e))
+			.map(|shape| {
+				shape
+					.map(|shape| {
+						let mut total = 0;
+						for r in space.intersect_shape(
+							shape.shape().as_ref(),
+							info.transform(),
+							info.collision_mask(),
+							exclude_bodies.as_deref(),
+							exclude_areas.as_deref(),
+							max_results,
+						) {
+							let (object_id, index) = match r.index {
+								BodyOrAreaIndex::Body(body) => (
+									body.map(|body| body.object_id()).expect("Invalid body"),
+									Index::Body(body),
+								),
+								BodyOrAreaIndex::Area(area) => (
+									area.map(|area| area.object_id()).expect("Invalid area"),
+									Index::Area(area),
+								),
+							};
+							results[total].set_index(index);
+							results[total].set_object_id(object_id);
+							results[total].set_shape(r.shape);
+							total += 1;
+						}
+						total
+					})
+					.map_err(|_| godot_error!("Invalid shape"))
+					.unwrap_or(0)
+			})
+			.unwrap_or(0)
+	})
+	.unwrap_or(0)
 }
 
 fn set_active(space: Index, active: bool) {

--- a/test/space_state/intersect.gd
+++ b/test/space_state/intersect.gd
@@ -1,0 +1,11 @@
+extends Spatial
+
+func _physics_process(_d):
+	for _i in 1000 * 1000 * 1000:
+		var param := PhysicsShapeQueryParameters.new()
+		var shape := SphereShape.new()
+		shape.radius = 10.0
+		param.set_shape(shape)
+		param.transform.origin = Vector3()
+		param.collision_mask = 0xffffffff
+		get_world().direct_space_state.intersect_shape(param)

--- a/test/space_state/intersect.tscn
+++ b/test/space_state/intersect.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://test/space_state/intersect.gd" type="Script" id=1]
+[ext_resource path="res://benchmark/stats.tscn" type="PackedScene" id=2]
+[ext_resource path="res://benchmark/bodies/box.tscn" type="PackedScene" id=3]
+
+[node name="Node" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="Stats" parent="." instance=ExtResource( 2 )]
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 6, 17 )
+
+[node name="Box" parent="." instance=ExtResource( 3 )]
+
+[node name="Box2" parent="." instance=ExtResource( 3 )]
+
+[node name="Box3" parent="." instance=ExtResource( 3 )]
+
+[node name="Box4" parent="." instance=ExtResource( 3 )]
+
+[node name="Box5" parent="." instance=ExtResource( 3 )]


### PR DESCRIPTION
The collision_mask assumed the test still used &&, while in Godot (and
the patched Rapier library) uses ||. It simply required replacing the
memberships/layer with 0 instead of u32::MAX.