### PR TITLE
Implement call to allow accessing additional functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ module/api.gen.h
 module/server.gen.cpp
 __pycache__/
 *.o
+*.pyc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rapier3d",
+ "wchar",
 ]
 
 [[package]]
@@ -1045,6 +1046,27 @@ name = "wasm-bindgen-shared"
 version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "wchar"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329ba7151d07f65f1ad4b38dc27369c952db9674bb65e6e8aad0b0bc206abf19"
+dependencies = [
+ "wchar-impl",
+]
+
+[[package]]
+name = "wchar-impl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98e30fc63796c670f6805bf5cbf2460766f663d7e804beef671ee845d33e39b"
+dependencies = [
+ "libc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "winapi"

--- a/module/generate.py
+++ b/module/generate.py
@@ -59,6 +59,7 @@ API_EXCLUDE = {
     'body_set_force_integration_callback',
     'body_get_direct_state',
     'body_get_collision_exceptions',
+    'call',
     'free',
     'soft_body_get_collision_exceptions',
     'soft_body_update_visual_server',
@@ -74,6 +75,11 @@ API_MAYBE_RIDS = {
 
 # Extra functions to add to the API
 API_CUSTOM_FUNCTIONS = {
+    'call': ('struct physics_call_result', [
+        ('const wchar_t *', 'method'),
+        ('const godot_variant **', 'args'),
+        ('size_t', 'arg_count'),
+    ]),
     'area_get_body_event': ('bool', [
         ('index_t', 'area'),
         ('struct physics_area_monitor_event *', 'event')
@@ -124,10 +130,24 @@ API_CUSTOM_FUNCTIONS = {
     'soft_body_get_collision_exception_count': ('int', [
         ('index_t', 'body')
     ]),
+    'server_get_index': ('index_t', [
+        ('const struct physics_server *', 'server'),
+        ('godot_rid', 'rid'),
+    ]),
+    'server_get_rid': ('godot_rid', [
+        ('const struct physics_server *', 'server'),
+        ('index_t', 'index'),
+    ]),
 }
 
 # Structs to include in the API
 API_STRUCTS = {
+    'physics_call_result': [
+        ('godot_variant', 'value'),
+        ('uint8_t', 'status'),
+        ('uint8_t', 'argument'),
+        ('uint8_t', 'expected_type'),
+    ],
     'physics_body_state': [
         ('godot_transform', 'transform'),
         ('godot_vector3', 'linear_velocity'),
@@ -190,7 +210,8 @@ API_STRUCTS = {
         ('index_t', 'id'),
         ('int', 'object_id'),
         ('bool', 'added'),
-    ]
+    ],
+    'physics_server': [],
 }
 
 # Functions for which to validate all RIDs

--- a/module/server.cpp
+++ b/module/server.cpp
@@ -68,11 +68,10 @@ void PluggablePhysicsServer::init() {
 		void (*init_func)(const struct physics_server *ps, struct fn_table *) = reinterpret_cast<void (*)(const struct physics_server *ps, struct fn_table *)>(handle);
 		// SAFETY: it's just a pointer
 		const struct physics_server *ps = reinterpret_cast<struct physics_server *>(this);
-		// I have no idea why the compiler complains without (void *) here but it does work & it's valid AFAICT.
 		// SAFETY: the two functions are ABI compatible.
-		this->fn_table.server_get_index = reinterpret_cast<index_t (*)(const struct physics_server *, godot_rid)>(&PluggablePhysicsServer::get_index);
+		this->fn_table.server_get_index = _get_index;
 		// SAFETY: Ditto 
-		this->fn_table.server_get_rid = reinterpret_cast<godot_rid (*)(const struct physics_server *, index_t)>(&PluggablePhysicsServer::get_rid);
+		this->fn_table.server_get_rid = _get_rid;
 		init_func(ps, &this->fn_table);
 	}
 }

--- a/module/server.cpp
+++ b/module/server.cpp
@@ -25,6 +25,8 @@ PluggablePhysicsServer::~PluggablePhysicsServer() {
 
 void PluggablePhysicsServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("step", "delta"), &PluggablePhysicsServer::step);
+	ClassDB::bind_method(D_METHOD("get_rid", "index"), &PluggablePhysicsServer::get_rid);
+	ClassDB::bind_method(D_METHOD("get_index", "rid"), &PluggablePhysicsServer::get_index);
 }
 
 void PluggablePhysicsServer::area_set_monitor_callback(RID area, Object *receiver, const StringName &method) {
@@ -63,9 +65,28 @@ void PluggablePhysicsServer::init() {
 		ERR_FAIL_COND_MSG(err, "Failed to get init handle");
 
 		// SAFETY: the callee must have the exact same signature
-		void (*init_func)(struct fn_table *) = reinterpret_cast<void (*)(struct fn_table *)>(handle);
-		init_func(&this->fn_table);
+		void (*init_func)(const struct physics_server *ps, struct fn_table *) = reinterpret_cast<void (*)(const struct physics_server *ps, struct fn_table *)>(handle);
+		// SAFETY: it's just a pointer
+		const struct physics_server *ps = reinterpret_cast<struct physics_server *>(this);
+		// SAFETY: the two functions are ABI compatible.
+		this->fn_table.server_get_index = reinterpret_cast<index_t (*)(const struct physics_server *, godot_rid)>(&PluggablePhysicsServer::get_index);
+		// SAFETY: Ditto 
+		this->fn_table.server_get_rid = reinterpret_cast<godot_rid (*)(const struct physics_server *, index_t)>(&PluggablePhysicsServer::get_rid);
+		init_func(ps, &this->fn_table);
 	}
+}
+
+Variant PluggablePhysicsServer::call(const StringName &method, const Variant **args, int argcount, Variant::CallError &error) {
+	ERR_FAIL_COND_V_MSG(this->fn_table.call == nullptr, Variant(), "Not implemented");
+	// TODO find a way that avoids potential redundant malloc calls.
+	// Because malloc may return NULL the compiler isn't always able to optimize it out if it
+	// would have side effects (e.g. error message).
+	String m(method);
+	struct physics_call_result result = (*this->fn_table.call)(m.ptr(), args, (size_t)argcount);
+	error.error = (Variant::CallError::Error)result.status;
+	error.argument = result.argument;
+	error.expected = (Variant::Type)result.expected_type;
+	return result.value;
 }
 
 void PluggablePhysicsServer::step(float delta) {

--- a/module/server.h
+++ b/module/server.h
@@ -96,6 +96,12 @@ class PluggablePhysicsServer : public PhysicsServer {
 		return rid;
 	}
 
+	/**
+	 * Returns the index associated with a RID. An index is a 64 bit integer used internally by the
+	 * physics engine and is necessary to use any of the additional methods.
+	 *
+	 * Returns `0` if the RID is invalid.
+	 */
 	_FORCE_INLINE_ index_t get_index(RID rid) const {
 		if (rid.is_valid()) {
 			PluggablePhysicsRID_Data *data = this->rids.get(rid);
@@ -104,12 +110,18 @@ class PluggablePhysicsServer : public PhysicsServer {
 		return 0;
 	}
 
+	/**
+	 * Returns the RID associated with an index. An index is a 64 bit integer used internally by the
+	 * physics engine and is necessary to use any of the additional methods.
+	 */
 	_FORCE_INLINE_ RID get_rid(index_t index) const {
 		return index != 0 ? this->reverse_rids.get(index) : RID();
 	}
 
 protected:
 	static void _bind_methods();
+
+	Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
 public:
 	PluggablePhysicsServer();

--- a/module/server.h
+++ b/module/server.h
@@ -118,6 +118,17 @@ class PluggablePhysicsServer : public PhysicsServer {
 		return index != 0 ? this->reverse_rids.get(index) : RID();
 	}
 
+	// Every line of C++ I write makes me hate the language even more.
+	//
+	// See https://isocpp.org/wiki/faq/pointers-to-members
+	static index_t _get_index(const struct physics_server *server, godot_rid rid) {
+		return reinterpret_cast<const PluggablePhysicsServer *>(server)->get_index(rid);
+	}
+
+	static godot_rid _get_rid(const struct physics_server *server, index_t index) {
+		return reinterpret_cast<const PluggablePhysicsServer *>(server)->get_rid(index);
+	}
+
 protected:
 	static void _bind_methods();
 

--- a/module/typedef.h
+++ b/module/typedef.h
@@ -9,5 +9,6 @@ typedef Vector3 godot_vector3;
 typedef Variant godot_variant;
 typedef StringName godot_string_name;
 typedef Object godot_object;
+typedef RID godot_rid;
 
 #endif

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -11,6 +11,7 @@ name = "godot_rapier3d"
 rapier3d = { git = "https://github.com/Demindiro/rapier", branch = "godot-0.9", version = "*", features = ["simd-nightly"] }
 gdnative = "*"
 lazy_static = "*"
+wchar = "*"
 
 [build-dependencies]
 json = "*"

--- a/rapier3d/src/body.rs
+++ b/rapier3d/src/body.rs
@@ -214,6 +214,7 @@ impl Body {
 			mp.local_com = Point3::new(0.0, 0.0, 0.0);
 		};
 		mp.inv_mass = body.mass_properties().inv_mass;
+		mp.local_com = body.mass_properties().local_com;
 		body.set_mass_properties(mp, true);
 		self.inertia_stale = false;
 	}
@@ -858,6 +859,15 @@ impl Body {
 			Axis::Z => 2,
 		};
 		self.map_rigidbody(|body| body.is_rotation_locked()[axis])
+	}
+
+	/// Set the local center of mass of this body.
+	pub fn set_local_com(&mut self, position: Vector3, wake_up: bool) {
+		self.map_rigidbody_mut(|body| {
+			let mut mp = *body.mass_properties();
+			mp.local_com = Point::new(position.x, position.y, position.z);
+			body.set_mass_properties(mp, wake_up);
+		})
 	}
 }
 

--- a/rapier3d/src/lib.rs
+++ b/rapier3d/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(destructuring_assignment)]
+#![feature(option_result_unwrap_unchecked)]
 
 mod area;
 mod body;

--- a/rapier3d/src/server/body.rs
+++ b/rapier3d/src/server/body.rs
@@ -438,33 +438,18 @@ mod call {
 
 	/// Set the local center of mass.
 	pub fn set_local_com(arguments: &[&Variant]) -> call::Result {
-		if arguments.len() < 2 {
-			Err(PhysicsCallError::TooFewArguments)
-		} else if arguments.len() > 3 {
-			Err(PhysicsCallError::TooManyArguments)
+		call_check_arg_count!(arguments in 2..3)?;
+		let body = call_get_arg!(arguments[0] => Rid)?;
+		let com = call_get_arg!(arguments[1] => Vector3)?;
+		let wake = call_get_arg!(arguments[2] => bool || true)?;
+		if let Ok(body) = super::get_index(body) {
+			map_or_err!(body, map_body_mut, |body, _| {
+				body.set_local_com(com, wake);
+			});
 		} else {
-			let body = arguments[0]
-				.try_to_rid()
-				.ok_or(PhysicsCallError::invalid_argument(0, VariantType::Rid))?;
-			let com = arguments[1]
-				.try_to_vector3()
-				.ok_or(PhysicsCallError::invalid_argument(0, VariantType::Vector3))?;
-			let wake = if let Some(v) = arguments.get(2) {
-				v
-					.try_to_bool()
-					.ok_or(PhysicsCallError::invalid_argument(0, VariantType::Bool))?
-			} else {
-				false
-			};
-			if let Ok(body) = super::get_index(body) {
-				map_or_err!(body, map_body_mut, |body, _| {
-					body.set_local_com(com, wake);
-				});
-			} else {
-				godot_error!("Invalid index");
-			}
-			Ok(Variant::new())
+			godot_error!("Invalid index");
 		}
+		Ok(Variant::new())
 	}
 }
 

--- a/rapier3d/src/server/call.rs
+++ b/rapier3d/src/server/call.rs
@@ -3,6 +3,56 @@ use gdnative::prelude::*;
 
 pub(super) type Result = core::result::Result<Variant, ffi::PhysicsCallError>;
 
+macro_rules! call_get_arg {
+	(@INTERNAL $args:expr, $index:literal, $ty_fn:ident, $ty:ident) => {
+		$args[$index]
+			.$ty_fn()
+			.ok_or(PhysicsCallError::invalid_argument($index, VariantType::$ty))
+	};
+	(@INTERNAL @maybe $args:expr, $index:literal, $ty_fn:ident, $ty:ident, $default:expr) => {
+		if let Some(v) = $args.get($index) {
+			v
+				.$ty_fn()
+				.ok_or(PhysicsCallError::invalid_argument($index, VariantType::$ty))
+		} else {
+			Ok($default)
+		}
+	};
+	($args:ident[$index:literal] => bool) => {
+		call_get_arg!(@INTERNAL $args, $index, try_to_bool, Bool)
+	};
+	($args:ident[$index:literal] => bool || $default:expr) => {
+		call_get_arg!(@INTERNAL @maybe $args, $index, try_to_bool, Bool, $default)
+	};
+	($args:ident[$index:literal] => Vector3) => {
+		call_get_arg!(@INTERNAL $args, $index, try_to_vector3, Vector3)
+	};
+	($args:ident[$index:literal] => Vector3 || $default:expr) => {
+		call_get_arg!(@INTERNAL @maybe $args, $index, try_to_vector3, Vector3, $default)
+	};
+	($args:ident[$index:literal] => Rid) => {
+		call_get_arg!(@INTERNAL $args, $index, try_to_rid, Rid)
+	};
+	($args:ident[$index:literal] => Rid || $default:expr) => {
+		call_get_arg!(@INTERNAL @maybe $args, $index, try_to_rid, Rid, $default)
+	};
+}
+
+macro_rules! call_check_arg_count {
+	($args:ident in $min:literal..$max:literal) => {
+		{
+			const _MIN_MAX_CHECK: usize = $max - $min;
+			if $args.len() < $min {
+				Err(PhysicsCallError::TooFewArguments)
+			} else if $args.len() > $max {
+				Err(PhysicsCallError::TooManyArguments)
+			} else {
+				Ok(())
+			}
+		}
+	}
+}
+
 /// Method used to access Rapier-specific functionality.
 pub(super) fn call(
 	method: *const wchar::wchar_t,

--- a/rapier3d/src/server/call.rs
+++ b/rapier3d/src/server/call.rs
@@ -1,0 +1,30 @@
+use super::*;
+use gdnative::prelude::*;
+
+pub(super) type Result = core::result::Result<Variant, ffi::PhysicsCallError>;
+
+/// Method used to access Rapier-specific functionality.
+pub(super) fn call(
+	method: *const wchar::wchar_t,
+	arguments: *const &Variant,
+	arguments_count: usize,
+) -> ffi::PhysicsCallResult {
+	// Godot's String includes a null char, so we can determine the length from that
+	let method = unsafe {
+		let mut size = 0;
+		let mut m = method;
+		while *m != 0 {
+			m = m.add(1);
+			size += 1;
+		}
+		core::slice::from_raw_parts(method, size)
+	};
+	// We'll have to trust Godot on this one (just like with 'method', really).
+	let arguments = unsafe { core::slice::from_raw_parts(arguments, arguments_count) };
+
+	use wchar::wch;
+	ffi::PhysicsCallResult::new(match method {
+		wch!("body_set_local_com") => body::set_local_com(arguments),
+		_ => Err(ffi::PhysicsCallError::InvalidMethod),
+	})
+}

--- a/rapier3d/src/server/ffi.rs
+++ b/rapier3d/src/server/ffi.rs
@@ -32,10 +32,7 @@ macro_rules! gdphysics_init {
 			if table.is_null() {
 				println!("Function table pointer is null");
 			} else {
-				let mut ffi = ffi::FFI {
-					table,
-					server,
-				};
+				let mut ffi = ffi::FFI { table, server };
 				$fn(&mut ffi);
 			}
 		}
@@ -128,7 +125,10 @@ impl From<VariantType> for u8 {
 
 impl PhysicsCallError {
 	pub fn invalid_argument(argument: u8, expected_type: VariantType) -> Self {
-		Self::InvalidArgument { argument, expected_type }
+		Self::InvalidArgument {
+			argument,
+			expected_type,
+		}
 	}
 }
 

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -2,6 +2,7 @@
 mod ffi;
 mod area;
 mod body;
+mod call;
 mod index;
 mod joint;
 mod shape;
@@ -14,7 +15,8 @@ use crate::space::Space;
 use crate::*;
 use core::convert::TryInto;
 use core::num::NonZeroU32;
-use gdnative::godot_error;
+use gdnative::core_types::{Rid, Variant};
+use gdnative::{godot_error, sys};
 pub use index::*;
 use joint::Joint;
 use rapier3d::na;
@@ -29,6 +31,10 @@ lazy_static::lazy_static! {
 	static ref SHAPE_INDICES: RwLock<Indices<Shape>> = RwLock::new(Indices::new());
 	static ref SPACE_INDICES: RwLock<Indices<Space>> = RwLock::new(Indices::new());
 }
+
+static mut PHYSICS_SERVER: Option<*const ffi::PhysicsServer> = None;
+static mut GET_RID: Option<unsafe extern "C" fn(*const ffi::PhysicsServer, u64) -> sys::godot_rid> = None;
+static mut GET_INDEX: Option<unsafe extern "C" fn(*const ffi::PhysicsServer, sys::godot_rid) -> u64> = None;
 
 pub enum Instance<A, L> {
 	Attached(A, SpaceIndex),
@@ -246,6 +252,12 @@ macro_rules! map_or_err {
 }
 
 fn init(ffi: &mut ffi::FFI) {
+	unsafe {
+		PHYSICS_SERVER = Some(ffi.server);
+		GET_INDEX = (*ffi.table).server_get_index;
+		GET_RID = (*ffi.table).server_get_rid;
+	}
+	ffi!(ffi, call, call::call);
 	ffi!(ffi, set_active, set_active);
 	ffi!(ffi, init, server_init);
 	ffi!(ffi, flush_queries, flush_queries);
@@ -332,4 +344,22 @@ fn get_process_info(info: i32) -> i32 {
 
 fn set_active(active: bool) {
 	*ACTIVE.write().expect("Failed to modify ACTIVE") = active;
+}
+
+fn get_index(rid: Rid) -> Result<Index, InvalidIndex> {
+	unsafe {
+		debug_assert!(PHYSICS_SERVER.is_some());
+		debug_assert!(GET_INDEX.is_some());
+		let index = GET_INDEX.unwrap_unchecked()(PHYSICS_SERVER.unwrap_unchecked(), *rid.sys());
+		Index::from_raw(index)
+	}
+}
+
+fn get_rid(index: Index) -> Rid {
+	unsafe {
+		debug_assert!(PHYSICS_SERVER.is_some());
+		debug_assert!(GET_RID.is_some());
+		let rid = GET_RID.unwrap_unchecked()(PHYSICS_SERVER.unwrap_unchecked(), index.raw());
+		Rid::from_sys(rid)
+	}
 }

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -1,8 +1,9 @@
 #[macro_use]
 mod ffi;
+#[macro_use]
+mod call;
 mod area;
 mod body;
-mod call;
 mod index;
 mod joint;
 mod shape;

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -34,8 +34,11 @@ lazy_static::lazy_static! {
 }
 
 static mut PHYSICS_SERVER: Option<*const ffi::PhysicsServer> = None;
-static mut GET_RID: Option<unsafe extern "C" fn(*const ffi::PhysicsServer, u64) -> sys::godot_rid> = None;
-static mut GET_INDEX: Option<unsafe extern "C" fn(*const ffi::PhysicsServer, sys::godot_rid) -> u64> = None;
+static mut GET_RID: Option<unsafe extern "C" fn(*const ffi::PhysicsServer, u64) -> sys::godot_rid> =
+	None;
+static mut GET_INDEX: Option<
+	unsafe extern "C" fn(*const ffi::PhysicsServer, sys::godot_rid) -> u64,
+> = None;
 
 pub enum Instance<A, L> {
 	Attached(A, SpaceIndex),

--- a/test/call/call.gd
+++ b/test/call/call.gd
@@ -1,0 +1,12 @@
+extends Node
+
+
+var acc = 0.0
+var si = -1.0
+func _physics_process(delta):
+	acc += delta
+	if acc >= 0.5:
+		var rid = $RigidBody.get_rid()
+		PhysicsServer.body_set_local_com(rid, Vector3(si * 10, 0, 0))
+		si = -si
+		acc = 0.0

--- a/test/call/call.tscn
+++ b/test/call/call.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://test/call/call.gd" type="Script" id=1]
+
+[sub_resource type="BoxShape" id=1]
+extents = Vector3( 3.68115, 0.441422, 3.04398 )
+
+[node name="Node" type="Node"]
+script = ExtResource( 1 )
+
+[node name="StaticBody" type="StaticBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.98989, 0 )
+
+[node name="CollisionShape" type="CollisionShape" parent="StaticBody"]
+shape = SubResource( 1 )
+
+[node name="RigidBody" type="RigidBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.472478, 0 )
+
+[node name="CollisionShape" type="CollisionShape" parent="RigidBody"]
+shape = SubResource( 1 )
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.899649, 0.436613, 0, -0.436613, 0.899649, 0, 5.89409, 15.18 )


### PR DESCRIPTION
This allows implementing additional Rapier-specific functionality without needing to modify the module (and recompiling the engine). It also keeps the module somewhat Rapier-agnostic.

From the Godot side it's fairly clean, but using it from the Rust side is still a bit ugly.

There is some overhead from the `get_rid` & `get_index` calls. There is not much that can be done about I'm afraid.

`body_set_local_com` has been implemented already as it was easy to do so & I also need it for another project.

Closes #38 