### PR TITLE
Box loose instances.

### DIFF
--- a/rapier3d/src/area.rs
+++ b/rapier3d/src/area.rs
@@ -80,7 +80,7 @@ impl Area {
 		Self {
 			index: None,
 			shapes: Vec::new(),
-			instance: Instance::Loose(RigidBodyBuilder::new_static().build()),
+			instance: Instance::loose(RigidBodyBuilder::new_static().build()),
 			scale: Vector3::one(),
 			linear_damp: 0.0,
 			angular_damp: 0.0,
@@ -307,13 +307,13 @@ impl Area {
 	/// Sets the space of this area. This removes the area from it's current space, if any.
 	pub fn set_space(&mut self, space: Option<SpaceIndex>) {
 		// Judging by the API areas are intended to be moved around, so use kinematic
-		let instance = Instance::Loose(RigidBodyBuilder::new_kinematic_position_based().build());
+		let instance = Instance::loose(RigidBodyBuilder::new_kinematic_position_based().build());
 		let instance = mem::replace(&mut self.instance, instance);
 		let body = match instance {
 			Instance::Attached((body, _), space) => space
 				.map_mut(|space| space.remove_body(body).expect("Invalid body handle"))
 				.expect("Invalid space"),
-			Instance::Loose(body) => body,
+			Instance::Loose(body) => *body,
 		};
 
 		self.instance = if let Some(space) = space {
@@ -342,7 +342,7 @@ impl Area {
 				.expect("Invalid space");
 			Instance::Attached(a, space)
 		} else {
-			Instance::Loose(body)
+			Instance::loose(body)
 		}
 	}
 

--- a/rapier3d/src/body.rs
+++ b/rapier3d/src/body.rs
@@ -77,7 +77,7 @@ pub struct InvalidShape;
 impl Body {
 	pub fn new(body: RigidBody) -> Self {
 		Self {
-			body: Instance::Loose(body),
+			body: Instance::loose(body),
 			object_id: None,
 			shapes: Vec::new(),
 			scale: Vector3::one(),
@@ -627,7 +627,7 @@ impl Body {
 		self.body = if let Instance::Loose(b) = b {
 			let mut collider_handles = Vec::with_capacity(colliders.len());
 			let mp = *b.mass_properties();
-			let handle = space.add_body(b);
+			let handle = space.add_body(*b);
 			for collider in colliders {
 				let handle = collider.map(|c| space.add_collider(c, handle));
 				collider_handles.push(handle);
@@ -653,7 +653,7 @@ impl Body {
 			let body = space
 				.map_mut(|space| space.remove_body(*body).expect("Invalid body handle"))
 				.expect("Failed to modify space");
-			self.body = Instance::Loose(body);
+			self.body = Instance::loose(body);
 		}
 	}
 

--- a/rapier3d/src/server/joint.rs
+++ b/rapier3d/src/server/joint.rs
@@ -76,7 +76,7 @@ impl Joint {
 			}
 		} else {
 			Self {
-				joint: Instance::Loose(LooseJoint {
+				joint: Instance::loose(LooseJoint {
 					params,
 					body_a,
 					body_b,

--- a/rapier3d/src/server/mod.rs
+++ b/rapier3d/src/server/mod.rs
@@ -42,7 +42,14 @@ static mut GET_INDEX: Option<
 
 pub enum Instance<A, L> {
 	Attached(A, SpaceIndex),
-	Loose(L),
+	Loose(Box<L>),
+}
+
+impl<A, L> Instance<A, L> {
+	/// Create a new loose instance
+	pub fn loose(item: L) -> Self {
+		Self::Loose(Box::new(item))
+	}
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Rapier's RigidBody and joint structures are quite large, which bloated
the `Instance` enum. This is very wasteful as loose instances are
uncommon. Storing them on the heap significantly reduces the sizes of
Areas, Bodies and Joints:

* Area: 488 -> 216

* Body: 536 -> 264

* Joint: 200 -> 32